### PR TITLE
Feature signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,13 +178,13 @@ _Which means that there are null returns within  `bar` and also within `foo`_
 
 ## An universal tool
 
-The really awesome is here: it is an universal tool which can _potentially_ work with every programming language. it natively supports: 
+The really awesome is here: it is an universal tool which can _potentially_ work with every programming language. it natively supports:
 
   * JS (ES5)
   * Haskell
   * Prolog
   * Gobstones
-  * Mulang itself, expressed as a JSON AST. 
+  * Mulang itself, expressed as a JSON AST.
 
 So in order to use it with a particular language, you have to:
 
@@ -201,31 +201,126 @@ But if you are not the Haskell inclined gal or guy - ok, I will try to forgive y
 Sample CLI usage...
 
 ...with advanced expectations:
-```
-$ mulang '{"expectations":[{"tag":"Advanced","subject":["x"],"transitive":false,"negated":false,"object":{"tag":"Anyone","contents":[]},"verb":"uses"}],"code":{"content":"x = 1","language":"Haskell"}}'
-{"results":[{"result":false,"expectation":{"subject":["x"],"tag":"Advanced","transitive":false,"negated":false,"object":{"tag":"Anyone","contents":[]},"verb":"uses"}}],"smells":[]}
+
+```bash
+$ mulang '
+{
+   "expectations" : [
+      {
+         "negated" : false,
+         "subject" : [
+            "x"
+         ],
+         "transitive" : false,
+         "object" : {
+            "tag" : "Anyone",
+            "contents" : []
+         },
+         "tag" : "Advanced",
+         "verb" : "uses"
+      }
+   ],
+   "code" : {
+      "content" : "x = 1",
+      "language" : "Haskell"
+   },
+   "analyseSignatures" : false
+}' | json_pp
+{
+   "results" : [
+      {
+         "expectation" : {
+            "tag" : "Advanced",
+            "object" : {
+               "tag" : "Anyone",
+               "contents" : []
+            },
+            "verb" : "uses",
+            "transitive" : false,
+            "negated" : false,
+            "subject" : [
+               "x"
+            ]
+         },
+         "result" : false
+      }
+   ],
+   "smells" : [],
+   "signatures" : []
+}
 ```
 
-...and with basic expectations:
+...with basic expectations:
+
+```bash
+$ mulang '
+{
+   "code" : {
+      "content" : "x = 1",
+      "language" : "Haskell"
+   },
+   "analyseSignatures" : false,
+   "expectations" : [
+      {
+         "tag" : "Basic",
+         "inspection" : "HasBinding",
+         "binding" : "x"
+      }
+   ]
+}' | json_pp
+{
+   "signatures" : [],
+   "smells" : [],
+   "results" : [
+      {
+         "result" : true,
+         "expectation" : {
+            "inspection" : "HasBinding",
+            "binding" : "x",
+            "tag" : "Basic"
+         }
+      }
+   ]
+}
+
 ```
-$ mulang '{"expectations":[{"tag":"Basic","binding":"x","inspection":"HasBinding"}],"code":{"content":"x = 1","language":"Haskell"}}'
-{"results":[{"result":true,"expectation":{"tag":"Basic","inspection":"HasBinding","binding":"x"}}],"smells":[]}
+
+...and with signature analysis:
+
+```bash
+$ mulang '
+{
+   "code" : {
+      "content" : "function foo(x, y) { return x + y; }",
+      "language" : "JavaScript"
+   },
+   "expectations" : [],
+   "analyseSignatures" : true
+}' | json_pp
+{
+   "results" : [],
+   "smells" : [],
+   "signatures" : [
+      "foo(x, y)"
+   ]
+}
 ```
 
-  
-## Expectations and Smells  
 
-Mulang CLI can do two different kinds of analysis: 
 
-* **Expectation analysis**: you can provide an expression - called `inspection` - that will be tested against the provied program. Expectations answer questions like: _does the function X call the function Y?_ or _does the program use if's?_. It comes in two flavors: 
-     * **basic expectations**: are composed by a binding and an inspection 
+## Expectations, Signatures and Smells
+
+Mulang CLI can do three different kinds of analysis:
+
+* **Expectation analysis**: you can provide an expression - called `inspection` - that will be tested against the provied program. Expectations answer questions like: _does the function X call the function Y?_ or _does the program use if's?_. It comes in two flavors:
+     * **basic expectations**: are composed by a binding and an inspection
      * **advanced expectations**: are composed by
        * subject
        * verb
        * object
        * flags
-* **Smell analysis**: instead of asking explcit questions to the program, the smells analysis implicitly runs specific inspections - that denote bad code - in orden to know if any of them is matched. 
-
+* **Smell analysis**: instead of asking explcit questions to the program, the smells analysis implicitly runs specific inspections - that denote bad code - in orden to know if any of them is matched.
+* **Signature analysis**: report the signatures of the computations present in source code.
 
 ## Building mulang from source
 
@@ -279,5 +374,5 @@ cabal repl
 And then, inside the REPL, do:
 
 ```
-:m Language.Mulang.All
+:m Language.Mulang
 ```

--- a/mulang.cabal
+++ b/mulang.cabal
@@ -75,6 +75,7 @@ library
     Language.Mulang.Binding
     Language.Mulang.Builder
     Language.Mulang.Explorer
+    Language.Mulang.Signature
     Language.Mulang.Inspector
     Language.Mulang.Inspector.Generic
     Language.Mulang.Inspector.ObjectOriented

--- a/mulang_pp
+++ b/mulang_pp
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+mulang "$1" | json_pp 
+

--- a/spec/CliSpec.hs
+++ b/spec/CliSpec.hs
@@ -1,4 +1,4 @@
-module EvaluatorSpec(spec) where
+module CliSpec(spec) where
 
 import           Language.Mulang.Cli.Interpreter
 import           Language.Mulang.Cli.Code
@@ -9,137 +9,137 @@ spec = describe "Evaluator" $ do
   describe "Advanced expectations" $ do
     it "evaluates unknown basic expectations" $ do
       let hasTurtle = Basic "x" "HasTurtle"
-      evaluate (Input (Code Haskell "x = 2") [hasTurtle]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = 2") [hasTurtle]) `shouldBe` (Output [
                                                                         ExpectationResult hasTurtle True] [])
 
     it "evaluates unknown basic negated expectations" $ do
       let notHasTurtle = Basic "x" "Not:HasTurtle"
-      evaluate (Input (Code Haskell "x = 2") [notHasTurtle]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = 2") [notHasTurtle]) `shouldBe` (Output [
                                                                         ExpectationResult notHasTurtle True] [])
 
 
     it "evaluates empty expectations" $ do
-      evaluate (Input (Code Haskell "x = 2") []) `shouldBe` (Output [] [])
+      evaluate (expectationsSample (Code Haskell "x = 2") []) `shouldBe` (Output [] [])
 
     it "detects smells" $ do
-      evaluate (Input (Code Haskell "f x = if x then True else False") []) `shouldBe` (Output [] [Basic "f" "HasRedundantIf"])
+      evaluate (expectationsSample (Code Haskell "f x = if x then True else False") []) `shouldBe` (Output [] [Basic "f" "HasRedundantIf"])
 
     it "evaluates present named expectations" $ do
       let ydeclares = (Advanced [] "declares" (Named "y") False False)
       let xdeclares = (Advanced [] "declares" (Named "x") False False)
-      evaluate (Input (Code Haskell "x = 2") [ydeclares, xdeclares]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = 2") [ydeclares, xdeclares]) `shouldBe` (Output [
                                                                           ExpectationResult ydeclares False,
                                                                           ExpectationResult xdeclares True] [])
 
     it "evaluates present expectations" $ do
       let declaresF = (Advanced [] "declaresFunction" Anyone False False)
       let declaresT = (Advanced [] "declaresTypeAlias" Anyone False False)
-      evaluate (Input (Code Haskell "f x = 2") [declaresF, declaresT]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "f x = 2") [declaresF, declaresT]) `shouldBe` (Output [
                                                                           ExpectationResult declaresF True,
                                                                           ExpectationResult declaresT False] [])
     it "works with plain mulang format" $ do
       let ydeclares = (Advanced [] "declares" (Named "y") False False)
       let code = Code Mulang "MuNull"
-      evaluate (Input code [ydeclares]) `shouldBe` (Output [ExpectationResult ydeclares False] [])
+      evaluate (expectationsSample code [ydeclares]) `shouldBe` (Output [ExpectationResult ydeclares False] [])
 
   describe "Basic expectations" $ do
     it "can be negated" $ do
       let notDeclaresx = (Basic "x" "Not:HasBinding")
       let notDeclaresy = (Basic "y" "Not:HasBinding")
-      evaluate (Input (Code Haskell "x = \"¡\"") [notDeclaresy, notDeclaresx]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = \"¡\"") [notDeclaresy, notDeclaresx]) `shouldBe` (Output [
                                                                           ExpectationResult notDeclaresy True,
                                                                           ExpectationResult notDeclaresx False] [])
 
     it "works with HasBinding" $ do
       let xdeclares = (Basic "x" "HasBinding")
       let ydeclares = (Basic "y" "HasBinding")
-      evaluate (Input (Code Haskell "x = 2") [ydeclares, xdeclares]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = 2") [ydeclares, xdeclares]) `shouldBe` (Output [
                                                                           ExpectationResult ydeclares False,
                                                                           ExpectationResult xdeclares True] [])
 
     it "works with HasUsage" $ do
       let usesy = (Basic "x" "HasUsage:y")
       let usesz = (Basic "x" "HasUsage:z")
-      evaluate (Input (Code Haskell "x = y * 10") [usesy, usesz]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = y * 10") [usesy, usesz]) `shouldBe` (Output [
                                                                           ExpectationResult usesy True,
                                                                           ExpectationResult usesz False] [])
 
     it "works with HasArity" $ do
       let hasArity2 = (Basic "foo" "HasArity:2")
       let hasArity3 = (Basic "foo" "HasArity:3")
-      evaluate (Input (Code Prolog "foo(x, y).") [hasArity2, hasArity3]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Prolog "foo(x, y).") [hasArity2, hasArity3]) `shouldBe` (Output [
                                                                           ExpectationResult hasArity2 True,
                                                                           ExpectationResult hasArity3 False] [])
 
     it "works with HasTypeSignature" $ do
       let hasTypeSignature = (Basic "f" "HasTypeSignature")
-      evaluate (Input (Code Haskell "f x y = y + x") [hasTypeSignature]) `shouldBe` (Output [ExpectationResult hasTypeSignature False] [])
-      evaluate (Input (Code Haskell "f :: Int -> Int -> Int \nf x y = y + x") [hasTypeSignature]) `shouldBe` (Output [ExpectationResult hasTypeSignature True] [])
+      evaluate (expectationsSample (Code Haskell "f x y = y + x") [hasTypeSignature]) `shouldBe` (Output [ExpectationResult hasTypeSignature False] [])
+      evaluate (expectationsSample (Code Haskell "f :: Int -> Int -> Int \nf x y = y + x") [hasTypeSignature]) `shouldBe` (Output [ExpectationResult hasTypeSignature True] [])
 
     it "works with HasTypeDeclaration" $ do
       let hasTypeDeclaration = (Basic "Words" "HasTypeDeclaration")
-      evaluate (Input (Code Haskell "type Works = [String]") [hasTypeDeclaration]) `shouldBe` (Output [ExpectationResult hasTypeDeclaration False] [])
-      evaluate (Input (Code Haskell "data Words = Words") [hasTypeDeclaration]) `shouldBe` (Output [ExpectationResult hasTypeDeclaration False] [])
-      evaluate (Input (Code Haskell "type Words = [String]") [hasTypeDeclaration]) `shouldBe` (Output [ExpectationResult hasTypeDeclaration True] [])
+      evaluate (expectationsSample (Code Haskell "type Works = [String]") [hasTypeDeclaration]) `shouldBe` (Output [ExpectationResult hasTypeDeclaration False] [])
+      evaluate (expectationsSample (Code Haskell "data Words = Words") [hasTypeDeclaration]) `shouldBe` (Output [ExpectationResult hasTypeDeclaration False] [])
+      evaluate (expectationsSample (Code Haskell "type Words = [String]") [hasTypeDeclaration]) `shouldBe` (Output [ExpectationResult hasTypeDeclaration True] [])
 
     it "works with HasIf" $ do
       let hasIf = (Basic "min" "HasIf")
-      evaluate (Input (Code Haskell "min x y = True") [hasIf]) `shouldBe` (Output [ExpectationResult hasIf False] [])
-      evaluate (Input (Code Haskell "min x y = if x < y then x else y") [hasIf]) `shouldBe` (Output [ExpectationResult hasIf True] [])
+      evaluate (expectationsSample (Code Haskell "min x y = True") [hasIf]) `shouldBe` (Output [ExpectationResult hasIf False] [])
+      evaluate (expectationsSample (Code Haskell "min x y = if x < y then x else y") [hasIf]) `shouldBe` (Output [ExpectationResult hasIf True] [])
 
     it "works with HasGuards" $ do
       let hasGuards = (Basic "min" "HasGuards")
-      evaluate (Input (Code Haskell "min x y = x") [hasGuards]) `shouldBe` (Output [ExpectationResult hasGuards False] [])
-      evaluate (Input (Code Haskell "min x y | x < y = x | otherwise = y") [hasGuards]) `shouldBe` (Output [ExpectationResult hasGuards True] [])
+      evaluate (expectationsSample (Code Haskell "min x y = x") [hasGuards]) `shouldBe` (Output [ExpectationResult hasGuards False] [])
+      evaluate (expectationsSample (Code Haskell "min x y | x < y = x | otherwise = y") [hasGuards]) `shouldBe` (Output [ExpectationResult hasGuards True] [])
 
     it "works with HasAnonymousVariable" $ do
       let hasAnonymousVariable = (Basic "c" "HasAnonymousVariable")
-      evaluate (Input (Code Haskell "c x = 14") [hasAnonymousVariable]) `shouldBe` (Output [ExpectationResult hasAnonymousVariable False] [])
-      evaluate (Input (Code Haskell "c _ = 14") [hasAnonymousVariable]) `shouldBe` (Output [ExpectationResult hasAnonymousVariable True] [])
+      evaluate (expectationsSample (Code Haskell "c x = 14") [hasAnonymousVariable]) `shouldBe` (Output [ExpectationResult hasAnonymousVariable False] [])
+      evaluate (expectationsSample (Code Haskell "c _ = 14") [hasAnonymousVariable]) `shouldBe` (Output [ExpectationResult hasAnonymousVariable True] [])
 
     it "works with HasRepeat" $ do
       pendingWith "Should be implemented when Gobstones support is ready"
 
     it "works with HasComposition" $ do
       let hasComposition = (Basic "h" "HasComposition")
-      evaluate (Input (Code Haskell "h = f") [hasComposition]) `shouldBe` (Output [ExpectationResult hasComposition False] [])
-      evaluate (Input (Code Haskell "h = f . g") [hasComposition]) `shouldBe` (Output [ExpectationResult hasComposition True] [])
+      evaluate (expectationsSample (Code Haskell "h = f") [hasComposition]) `shouldBe` (Output [ExpectationResult hasComposition False] [])
+      evaluate (expectationsSample (Code Haskell "h = f . g") [hasComposition]) `shouldBe` (Output [ExpectationResult hasComposition True] [])
 
     it "works with HasComprehension" $ do
       let hasComprehension = (Basic "x" "HasComprehension")
-      evaluate (Input (Code Haskell "x = [m | m <- t]") [hasComprehension]) `shouldBe` (Output [ExpectationResult hasComprehension True] [])
+      evaluate (expectationsSample (Code Haskell "x = [m | m <- t]") [hasComprehension]) `shouldBe` (Output [ExpectationResult hasComprehension True] [])
 
     it "works with HasConditional" $ do
       let hasConditional = (Basic "min" "HasConditional")
-      evaluate (Input (Code JavaScript "function min(x, y) { if (x < y) { return x } else { return y } }") [hasConditional]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code JavaScript "function min(x, y) { if (x < y) { return x } else { return y } }") [hasConditional]) `shouldBe` (Output [
                                                                                                             ExpectationResult hasConditional True] [])
 
     it "works with HasWhile" $ do
       let hasWhile = (Basic "f" "HasWhile")
-      evaluate (Input (Code JavaScript "function f() { var x = 5; while (x < 10) { x++ } }") [hasWhile]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code JavaScript "function f() { var x = 5; while (x < 10) { x++ } }") [hasWhile]) `shouldBe` (Output [
                                                                                                             ExpectationResult hasWhile True] [])
 
     it "works with HasForall" $ do
       let hasForall = (Basic "f" "HasForall")
-      evaluate (Input (Code Prolog "f(X) :- isElement(Usuario), forall(isRelated(X, Y), complies(Y)).") [hasForall]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Prolog "f(X) :- isElement(Usuario), forall(isRelated(X, Y), complies(Y)).") [hasForall]) `shouldBe` (Output [
                                                                                                             ExpectationResult hasForall True] [])
 
     it "works with HasFindall" $ do
       let hasFindall = (Basic "baz" "HasFindall")
-      evaluate (Input (Code Prolog "baz(X):- bar(X, Y).") [hasFindall]) `shouldBe` (Output [ExpectationResult hasFindall False] [])
-      evaluate (Input (Code Prolog "baz(X):- findall(Y, bar(X, Y), Z).") [hasFindall]) `shouldBe` (Output [ExpectationResult hasFindall True] [])
+      evaluate (expectationsSample (Code Prolog "baz(X):- bar(X, Y).") [hasFindall]) `shouldBe` (Output [ExpectationResult hasFindall False] [])
+      evaluate (expectationsSample (Code Prolog "baz(X):- findall(Y, bar(X, Y), Z).") [hasFindall]) `shouldBe` (Output [ExpectationResult hasFindall True] [])
 
     it "works with HasLambda" $ do
       let hasLambda = (Basic "f" "HasLambda")
-      evaluate (Input (Code Haskell "f = map id") [hasLambda]) `shouldBe` (Output [ExpectationResult hasLambda False] [])
-      evaluate (Input (Code Haskell "f = map $ \\x -> x + 1") [hasLambda]) `shouldBe` (Output [ExpectationResult hasLambda True] [])
+      evaluate (expectationsSample (Code Haskell "f = map id") [hasLambda]) `shouldBe` (Output [ExpectationResult hasLambda False] [])
+      evaluate (expectationsSample (Code Haskell "f = map $ \\x -> x + 1") [hasLambda]) `shouldBe` (Output [ExpectationResult hasLambda True] [])
 
     it "works with HasDirectRecursion" $ do
       let hasDirectRecursion = (Basic "f" "HasDirectRecursion")
-      evaluate (Input (Code Haskell "f x = if x < 5 then g (x - 1) else 2") [hasDirectRecursion]) `shouldBe` (Output [ExpectationResult hasDirectRecursion False] [])
-      evaluate (Input (Code Haskell "f x = if x < 5 then f (x - 1) else 2") [hasDirectRecursion]) `shouldBe` (Output [ExpectationResult hasDirectRecursion True] [])
+      evaluate (expectationsSample (Code Haskell "f x = if x < 5 then g (x - 1) else 2") [hasDirectRecursion]) `shouldBe` (Output [ExpectationResult hasDirectRecursion False] [])
+      evaluate (expectationsSample (Code Haskell "f x = if x < 5 then f (x - 1) else 2") [hasDirectRecursion]) `shouldBe` (Output [ExpectationResult hasDirectRecursion True] [])
 
     it "works with HasNot" $ do
       let hasNot = (Basic "foo" "HasNot")
-      evaluate (Input (Code Prolog "foo(X) :- bar(X).") [hasNot]) `shouldBe` (Output [ExpectationResult hasNot False] [])
-      evaluate (Input (Code Prolog "foo(X) :- not(bar(X)).") [hasNot]) `shouldBe` (Output [ExpectationResult hasNot True] [])
+      evaluate (expectationsSample (Code Prolog "foo(X) :- bar(X).") [hasNot]) `shouldBe` (Output [ExpectationResult hasNot False] [])
+      evaluate (expectationsSample (Code Prolog "foo(X) :- not(bar(X)).") [hasNot]) `shouldBe` (Output [ExpectationResult hasNot True] [])

--- a/spec/CliSpec.hs
+++ b/spec/CliSpec.hs
@@ -5,140 +5,142 @@ import           Language.Mulang.Cli.Code
 import           Language.Mulang.Cli.Compiler
 import           Test.Hspec
 
+expectationsAnalysysResult expectationsResults smellResults = Output expectationsResults smellResults []
+
 spec = describe "Evaluator" $ do
   describe "Advanced expectations" $ do
     it "evaluates unknown basic expectations" $ do
       let hasTurtle = Basic "x" "HasTurtle"
-      evaluate (expectationsSample (Code Haskell "x = 2") [hasTurtle]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = 2") [hasTurtle]) `shouldBe` (expectationsAnalysysResult [
                                                                         ExpectationResult hasTurtle True] [])
 
     it "evaluates unknown basic negated expectations" $ do
       let notHasTurtle = Basic "x" "Not:HasTurtle"
-      evaluate (expectationsSample (Code Haskell "x = 2") [notHasTurtle]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = 2") [notHasTurtle]) `shouldBe` (expectationsAnalysysResult [
                                                                         ExpectationResult notHasTurtle True] [])
 
     it "evaluates empty expectations" $ do
-      evaluate (expectationsSample (Code Haskell "x = 2") []) `shouldBe` (Output [] [])
+      evaluate (expectationsSample (Code Haskell "x = 2") []) `shouldBe` (expectationsAnalysysResult [] [])
 
     it "detects smells" $ do
-      evaluate (expectationsSample (Code Haskell "f x = if x then True else False") []) `shouldBe` (Output [] [Basic "f" "HasRedundantIf"])
+      evaluate (expectationsSample (Code Haskell "f x = if x then True else False") []) `shouldBe` (expectationsAnalysysResult [] [Basic "f" "HasRedundantIf"])
 
     it "evaluates present named expectations" $ do
       let ydeclares = (Advanced [] "declares" (Named "y") False False)
       let xdeclares = (Advanced [] "declares" (Named "x") False False)
-      evaluate (expectationsSample (Code Haskell "x = 2") [ydeclares, xdeclares]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = 2") [ydeclares, xdeclares]) `shouldBe` (expectationsAnalysysResult [
                                                                           ExpectationResult ydeclares False,
                                                                           ExpectationResult xdeclares True] [])
 
     it "evaluates present expectations" $ do
       let declaresF = (Advanced [] "declaresFunction" Anyone False False)
       let declaresT = (Advanced [] "declaresTypeAlias" Anyone False False)
-      evaluate (expectationsSample (Code Haskell "f x = 2") [declaresF, declaresT]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "f x = 2") [declaresF, declaresT]) `shouldBe` (expectationsAnalysysResult [
                                                                           ExpectationResult declaresF True,
                                                                           ExpectationResult declaresT False] [])
     it "works with plain mulang format" $ do
       let ydeclares = (Advanced [] "declares" (Named "y") False False)
       let code = Code Mulang "MuNull"
-      evaluate (expectationsSample code [ydeclares]) `shouldBe` (Output [ExpectationResult ydeclares False] [])
+      evaluate (expectationsSample code [ydeclares]) `shouldBe` (expectationsAnalysysResult [ExpectationResult ydeclares False] [])
 
   describe "Basic expectations" $ do
     it "can be negated" $ do
       let notDeclaresx = (Basic "x" "Not:HasBinding")
       let notDeclaresy = (Basic "y" "Not:HasBinding")
-      evaluate (expectationsSample (Code Haskell "x = \"¡\"") [notDeclaresy, notDeclaresx]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = \"¡\"") [notDeclaresy, notDeclaresx]) `shouldBe` (expectationsAnalysysResult [
                                                                           ExpectationResult notDeclaresy True,
                                                                           ExpectationResult notDeclaresx False] [])
 
     it "works with HasBinding" $ do
       let xdeclares = (Basic "x" "HasBinding")
       let ydeclares = (Basic "y" "HasBinding")
-      evaluate (expectationsSample (Code Haskell "x = 2") [ydeclares, xdeclares]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = 2") [ydeclares, xdeclares]) `shouldBe` (expectationsAnalysysResult [
                                                                           ExpectationResult ydeclares False,
                                                                           ExpectationResult xdeclares True] [])
 
     it "works with HasUsage" $ do
       let usesy = (Basic "x" "HasUsage:y")
       let usesz = (Basic "x" "HasUsage:z")
-      evaluate (expectationsSample (Code Haskell "x = y * 10") [usesy, usesz]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Haskell "x = y * 10") [usesy, usesz]) `shouldBe` (expectationsAnalysysResult [
                                                                           ExpectationResult usesy True,
                                                                           ExpectationResult usesz False] [])
 
     it "works with HasArity" $ do
       let hasArity2 = (Basic "foo" "HasArity:2")
       let hasArity3 = (Basic "foo" "HasArity:3")
-      evaluate (expectationsSample (Code Prolog "foo(x, y).") [hasArity2, hasArity3]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Prolog "foo(x, y).") [hasArity2, hasArity3]) `shouldBe` (expectationsAnalysysResult [
                                                                           ExpectationResult hasArity2 True,
                                                                           ExpectationResult hasArity3 False] [])
 
     it "works with HasTypeSignature" $ do
       let hasTypeSignature = (Basic "f" "HasTypeSignature")
-      evaluate (expectationsSample (Code Haskell "f x y = y + x") [hasTypeSignature]) `shouldBe` (Output [ExpectationResult hasTypeSignature False] [])
-      evaluate (expectationsSample (Code Haskell "f :: Int -> Int -> Int \nf x y = y + x") [hasTypeSignature]) `shouldBe` (Output [ExpectationResult hasTypeSignature True] [])
+      evaluate (expectationsSample (Code Haskell "f x y = y + x") [hasTypeSignature]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasTypeSignature False] [])
+      evaluate (expectationsSample (Code Haskell "f :: Int -> Int -> Int \nf x y = y + x") [hasTypeSignature]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasTypeSignature True] [])
 
     it "works with HasTypeDeclaration" $ do
       let hasTypeDeclaration = (Basic "Words" "HasTypeDeclaration")
-      evaluate (expectationsSample (Code Haskell "type Works = [String]") [hasTypeDeclaration]) `shouldBe` (Output [ExpectationResult hasTypeDeclaration False] [])
-      evaluate (expectationsSample (Code Haskell "data Words = Words") [hasTypeDeclaration]) `shouldBe` (Output [ExpectationResult hasTypeDeclaration False] [])
-      evaluate (expectationsSample (Code Haskell "type Words = [String]") [hasTypeDeclaration]) `shouldBe` (Output [ExpectationResult hasTypeDeclaration True] [])
+      evaluate (expectationsSample (Code Haskell "type Works = [String]") [hasTypeDeclaration]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasTypeDeclaration False] [])
+      evaluate (expectationsSample (Code Haskell "data Words = Words") [hasTypeDeclaration]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasTypeDeclaration False] [])
+      evaluate (expectationsSample (Code Haskell "type Words = [String]") [hasTypeDeclaration]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasTypeDeclaration True] [])
 
     it "works with HasIf" $ do
       let hasIf = (Basic "min" "HasIf")
-      evaluate (expectationsSample (Code Haskell "min x y = True") [hasIf]) `shouldBe` (Output [ExpectationResult hasIf False] [])
-      evaluate (expectationsSample (Code Haskell "min x y = if x < y then x else y") [hasIf]) `shouldBe` (Output [ExpectationResult hasIf True] [])
+      evaluate (expectationsSample (Code Haskell "min x y = True") [hasIf]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasIf False] [])
+      evaluate (expectationsSample (Code Haskell "min x y = if x < y then x else y") [hasIf]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasIf True] [])
 
     it "works with HasGuards" $ do
       let hasGuards = (Basic "min" "HasGuards")
-      evaluate (expectationsSample (Code Haskell "min x y = x") [hasGuards]) `shouldBe` (Output [ExpectationResult hasGuards False] [])
-      evaluate (expectationsSample (Code Haskell "min x y | x < y = x | otherwise = y") [hasGuards]) `shouldBe` (Output [ExpectationResult hasGuards True] [])
+      evaluate (expectationsSample (Code Haskell "min x y = x") [hasGuards]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasGuards False] [])
+      evaluate (expectationsSample (Code Haskell "min x y | x < y = x | otherwise = y") [hasGuards]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasGuards True] [])
 
     it "works with HasAnonymousVariable" $ do
       let hasAnonymousVariable = (Basic "c" "HasAnonymousVariable")
-      evaluate (expectationsSample (Code Haskell "c x = 14") [hasAnonymousVariable]) `shouldBe` (Output [ExpectationResult hasAnonymousVariable False] [])
-      evaluate (expectationsSample (Code Haskell "c _ = 14") [hasAnonymousVariable]) `shouldBe` (Output [ExpectationResult hasAnonymousVariable True] [])
+      evaluate (expectationsSample (Code Haskell "c x = 14") [hasAnonymousVariable]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasAnonymousVariable False] [])
+      evaluate (expectationsSample (Code Haskell "c _ = 14") [hasAnonymousVariable]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasAnonymousVariable True] [])
 
     it "works with HasRepeat" $ do
       pendingWith "Should be implemented when Gobstones support is ready"
 
     it "works with HasComposition" $ do
       let hasComposition = (Basic "h" "HasComposition")
-      evaluate (expectationsSample (Code Haskell "h = f") [hasComposition]) `shouldBe` (Output [ExpectationResult hasComposition False] [])
-      evaluate (expectationsSample (Code Haskell "h = f . g") [hasComposition]) `shouldBe` (Output [ExpectationResult hasComposition True] [])
+      evaluate (expectationsSample (Code Haskell "h = f") [hasComposition]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasComposition False] [])
+      evaluate (expectationsSample (Code Haskell "h = f . g") [hasComposition]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasComposition True] [])
 
     it "works with HasComprehension" $ do
       let hasComprehension = (Basic "x" "HasComprehension")
-      evaluate (expectationsSample (Code Haskell "x = [m | m <- t]") [hasComprehension]) `shouldBe` (Output [ExpectationResult hasComprehension True] [])
+      evaluate (expectationsSample (Code Haskell "x = [m | m <- t]") [hasComprehension]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasComprehension True] [])
 
     it "works with HasConditional" $ do
       let hasConditional = (Basic "min" "HasConditional")
-      evaluate (expectationsSample (Code JavaScript "function min(x, y) { if (x < y) { return x } else { return y } }") [hasConditional]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code JavaScript "function min(x, y) { if (x < y) { return x } else { return y } }") [hasConditional]) `shouldBe` (expectationsAnalysysResult [
                                                                                                             ExpectationResult hasConditional True] [])
 
     it "works with HasWhile" $ do
       let hasWhile = (Basic "f" "HasWhile")
-      evaluate (expectationsSample (Code JavaScript "function f() { var x = 5; while (x < 10) { x++ } }") [hasWhile]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code JavaScript "function f() { var x = 5; while (x < 10) { x++ } }") [hasWhile]) `shouldBe` (expectationsAnalysysResult [
                                                                                                             ExpectationResult hasWhile True] [])
 
     it "works with HasForall" $ do
       let hasForall = (Basic "f" "HasForall")
-      evaluate (expectationsSample (Code Prolog "f(X) :- isElement(Usuario), forall(isRelated(X, Y), complies(Y)).") [hasForall]) `shouldBe` (Output [
+      evaluate (expectationsSample (Code Prolog "f(X) :- isElement(Usuario), forall(isRelated(X, Y), complies(Y)).") [hasForall]) `shouldBe` (expectationsAnalysysResult [
                                                                                                             ExpectationResult hasForall True] [])
 
     it "works with HasFindall" $ do
       let hasFindall = (Basic "baz" "HasFindall")
-      evaluate (expectationsSample (Code Prolog "baz(X):- bar(X, Y).") [hasFindall]) `shouldBe` (Output [ExpectationResult hasFindall False] [])
-      evaluate (expectationsSample (Code Prolog "baz(X):- findall(Y, bar(X, Y), Z).") [hasFindall]) `shouldBe` (Output [ExpectationResult hasFindall True] [])
+      evaluate (expectationsSample (Code Prolog "baz(X):- bar(X, Y).") [hasFindall]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasFindall False] [])
+      evaluate (expectationsSample (Code Prolog "baz(X):- findall(Y, bar(X, Y), Z).") [hasFindall]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasFindall True] [])
 
     it "works with HasLambda" $ do
       let hasLambda = (Basic "f" "HasLambda")
-      evaluate (expectationsSample (Code Haskell "f = map id") [hasLambda]) `shouldBe` (Output [ExpectationResult hasLambda False] [])
-      evaluate (expectationsSample (Code Haskell "f = map $ \\x -> x + 1") [hasLambda]) `shouldBe` (Output [ExpectationResult hasLambda True] [])
+      evaluate (expectationsSample (Code Haskell "f = map id") [hasLambda]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasLambda False] [])
+      evaluate (expectationsSample (Code Haskell "f = map $ \\x -> x + 1") [hasLambda]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasLambda True] [])
 
     it "works with HasDirectRecursion" $ do
       let hasDirectRecursion = (Basic "f" "HasDirectRecursion")
-      evaluate (expectationsSample (Code Haskell "f x = if x < 5 then g (x - 1) else 2") [hasDirectRecursion]) `shouldBe` (Output [ExpectationResult hasDirectRecursion False] [])
-      evaluate (expectationsSample (Code Haskell "f x = if x < 5 then f (x - 1) else 2") [hasDirectRecursion]) `shouldBe` (Output [ExpectationResult hasDirectRecursion True] [])
+      evaluate (expectationsSample (Code Haskell "f x = if x < 5 then g (x - 1) else 2") [hasDirectRecursion]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasDirectRecursion False] [])
+      evaluate (expectationsSample (Code Haskell "f x = if x < 5 then f (x - 1) else 2") [hasDirectRecursion]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasDirectRecursion True] [])
 
     it "works with HasNot" $ do
       let hasNot = (Basic "foo" "HasNot")
-      evaluate (expectationsSample (Code Prolog "foo(X) :- bar(X).") [hasNot]) `shouldBe` (Output [ExpectationResult hasNot False] [])
-      evaluate (expectationsSample (Code Prolog "foo(X) :- not(bar(X)).") [hasNot]) `shouldBe` (Output [ExpectationResult hasNot True] [])
+      evaluate (expectationsSample (Code Prolog "foo(X) :- bar(X).") [hasNot]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasNot False] [])
+      evaluate (expectationsSample (Code Prolog "foo(X) :- not(bar(X)).") [hasNot]) `shouldBe` (expectationsAnalysysResult [ExpectationResult hasNot True] [])

--- a/spec/CliSpec.hs
+++ b/spec/CliSpec.hs
@@ -17,7 +17,6 @@ spec = describe "Evaluator" $ do
       evaluate (expectationsSample (Code Haskell "x = 2") [notHasTurtle]) `shouldBe` (Output [
                                                                         ExpectationResult notHasTurtle True] [])
 
-
     it "evaluates empty expectations" $ do
       evaluate (expectationsSample (Code Haskell "x = 2") []) `shouldBe` (Output [] [])
 

--- a/spec/SignatureSpec.hs
+++ b/spec/SignatureSpec.hs
@@ -6,10 +6,19 @@ import           Language.Mulang.Signature
 import           Language.Mulang.Parsers.Haskell
 import           Language.Mulang.Parsers.JavaScript
 import           Language.Mulang.Parsers.Prolog
-import           Language.Mulang.Explorer
 
 spec :: Spec
 spec = do
+  describe "codeSignatures" $ do
+    it "works with named signatures" $ do
+      codeSignaturesOf (js "function x(y, z) {}") `shouldBe` ["x(y, z)"]
+
+    it "works with types signatures" $ do
+      codeSignaturesOf (hs "x :: Int -> Int") `shouldBe` ["x :: Int -> Int"]
+
+    it "works with arity signatures" $ do
+      codeSignaturesOf (pl "x(Y, Z) :- g(Z), f(z).") `shouldBe` ["x/2"]
+
   describe "unhandled declaration" $ do
     it "object declaration" $ do
       signaturesOf (js "var x = {}") `shouldBe` []

--- a/spec/SignatureSpec.hs
+++ b/spec/SignatureSpec.hs
@@ -44,6 +44,9 @@ spec = do
     it "simple function type declaration" $ do
       signaturesOf (hs "foo :: Int -> Int") `shouldBe` [TypedSignature "foo" ["Int", "Int"]]
 
+    it "simple function tuple declaration" $ do
+      signaturesOf (hs "foo :: b -> (Int, [a])") `shouldBe` [TypedSignature "foo" ["b", "(Int, [a])"]]
+
   describe "NamedSignature" $ do
     it "empty expression" $ do
       signaturesOf (js "") `shouldBe` []

--- a/spec/SignatureSpec.hs
+++ b/spec/SignatureSpec.hs
@@ -20,7 +20,8 @@ signatureOf (RuleDeclaration name args _)         = AritySignature name (length 
 signatureOf (FactDeclaration name args)           = AritySignature name (length args)
 
 parameterNamesOf :: [Equation] -> [Maybe Binding]
-parameterNamesOf ((Equation parameters _):_) = map parameterNameOf parameters
+parameterNamesOf = compact . map (map parameterNameOf.equationParams)
+    where compact = head
 
 parameterNameOf :: Pattern -> Maybe Binding
 parameterNameOf (VariablePattern v) = Just v

--- a/spec/SignatureSpec.hs
+++ b/spec/SignatureSpec.hs
@@ -1,0 +1,70 @@
+module SignatureSpec (spec) where
+
+import           Test.Hspec
+import           Data.List
+import           Language.Mulang
+import           Language.Mulang.Signature
+import           Language.Mulang.Parsers.Haskell
+import           Language.Mulang.Parsers.JavaScript
+import           Language.Mulang.Parsers.Prolog
+import           Language.Mulang.Explorer
+
+signaturesOf :: Expression -> [Signature]
+signaturesOf = nub . map (signatureOf.snd) . declarationsOf
+
+signatureOf :: Expression -> Signature
+signatureOf (FunctionDeclaration name equations)  = NamedSignature name (parameterNamesOf equations)
+signatureOf (ProcedureDeclaration name equations) = NamedSignature name (parameterNamesOf equations)
+signatureOf (MethodDeclaration name equations)    = NamedSignature name (parameterNamesOf equations)
+signatureOf (RuleDeclaration name args _)         = AritySignature name (length args)
+signatureOf (FactDeclaration name args)           = AritySignature name (length args)
+
+parameterNamesOf :: [Equation] -> [Maybe Binding]
+parameterNamesOf ((Equation parameters _):_) = map parameterNameOf parameters
+
+parameterNameOf :: Pattern -> Maybe Binding
+parameterNameOf (VariablePattern v) = Just v
+parameterNameOf _                   = Nothing
+
+spec :: Spec
+spec = do
+  describe "NamedSignature" $ do
+    it "empty expression" $ do
+      signaturesOf (js "") `shouldBe` []
+
+    it "nullary function" $ do
+      signaturesOf (js "function foo() {}") `shouldBe` [NamedSignature "foo" []]
+
+    it "one-arg function" $ do
+      signaturesOf (js "function foo(x) {}") `shouldBe` [NamedSignature "foo" [Just "x"]]
+
+    it "binary function" $ do
+      signaturesOf (js "function foo(x, y) {}") `shouldBe` [NamedSignature "foo" [Just "x", Just "y"]]
+
+    it "binary function with non variable pattern" $ do
+      signaturesOf (hs "foo x _ = x") `shouldBe` [NamedSignature "foo" [Just "x", Nothing]]
+
+    it "binary function with multiple equations" $ do
+      signaturesOf (hs "foo x 1 = x\nfoo _ y = y") `shouldBe` [NamedSignature "foo" [Just "x", Just "y"]]
+
+  describe "AritySignature" $ do
+    it "empty expression" $ do
+      signaturesOf (pl "") `shouldBe` []
+
+    it "just a fact" $ do
+      signaturesOf (pl "good(dog).") `shouldBe` [AritySignature "good" 1]
+
+    it "two facts" $ do
+      signaturesOf (pl "good(dog).good(cat).") `shouldBe` [AritySignature "good" 1]
+
+    it "a fact of arity 2" $ do
+      signaturesOf (pl "legs(dog, 4).") `shouldBe` [AritySignature "legs" 2]
+
+    it "a fact of arity 2 and another of arity 3" $ do
+      signaturesOf (pl "legs(dog, 4).wings(dragon).wings(bird).") `shouldBe` [
+                                                                      AritySignature "legs" 2,
+                                                                      AritySignature "wings" 1]
+    it "two facts of same name, different arity" $ do
+      signaturesOf (pl "legs(dog, 4).legs(dragon).") `shouldBe` [ AritySignature "legs" 2,
+                                                                  AritySignature "legs" 1]
+

--- a/spec/SignatureSpec.hs
+++ b/spec/SignatureSpec.hs
@@ -54,7 +54,7 @@ spec = do
     it "binary function with non variable pattern" $ do
       signaturesOf (hs "foo x _ = x") `shouldBe` [NamedSignature "foo" [Just "x", Nothing]]
 
-    it "binary function with multiple complmentary equations" $ do
+    it "binary function with multiple complementary equations" $ do
       signaturesOf (hs "foo x 1 = x\nfoo _ y = y") `shouldBe` [
                                                       NamedSignature "foo" [Just "x", Just "y"]]
 

--- a/spec/SignatureSpec.hs
+++ b/spec/SignatureSpec.hs
@@ -8,29 +8,6 @@ import           Language.Mulang.Parsers.JavaScript
 import           Language.Mulang.Parsers.Prolog
 import           Language.Mulang.Explorer
 
-import           Data.List (transpose, nub)
-import           Data.Maybe (mapMaybe)
-import           Control.Monad (msum)
-
-signaturesOf :: Expression -> [Signature]
-signaturesOf = nub . mapMaybe (signatureOf.snd) . declarationsOf
-
-signatureOf :: Expression -> Maybe Signature
-signatureOf (FunctionDeclaration name equations)  = Just $ NamedSignature name (parameterNamesOf equations)
-signatureOf (ProcedureDeclaration name equations) = Just $ NamedSignature name (parameterNamesOf equations)
-signatureOf (RuleDeclaration name args _)         = Just $ AritySignature name (length args)
-signatureOf (FactDeclaration name args)           = Just $ AritySignature name (length args)
-signatureOf (TypeSignature name args)             = Just $ TypedSignature name args
-signatureOf (VariableDeclaration name _)          = Just $ AritySignature name 0
-signatureOf _                                     = Nothing
-
-parameterNamesOf :: [Equation] -> [Maybe Binding]
-parameterNamesOf = map msum . transpose . map (map parameterNameOf . equationParams)
-
-parameterNameOf :: Pattern -> Maybe Binding
-parameterNameOf (VariablePattern v) = Just v
-parameterNameOf _                   = Nothing
-
 spec :: Spec
 spec = do
   describe "unhandled declaration" $ do

--- a/src/Language/Mulang/Ast.hs
+++ b/src/Language/Mulang/Ast.hs
@@ -12,6 +12,10 @@
 -- |    * logic programing
 -- |
 module Language.Mulang.Ast (
+    equationParams,
+    unguardedEquationBody,
+    simpleProcedureBody,
+    simpleFunctionBody,
     Equation(..),
     EquationBody(..),
     Expression(..),
@@ -104,4 +108,17 @@ data ComprehensionStatement
         | MuQualifier Expression
         | LetStmt     Expression
   deriving (Eq, Show, Read, Generic)
+
+
+equationParams :: Equation -> [Pattern]
+equationParams (Equation p _) = p
+
+unguardedEquationBody :: Equation -> Expression
+unguardedEquationBody (Equation _ (UnguardedBody body)) = body
+
+simpleProcedureBody :: Expression -> Expression
+simpleProcedureBody (ProcedureDeclaration _ [equation]) = unguardedEquationBody equation
+
+simpleFunctionBody :: Expression -> Expression
+simpleFunctionBody (FunctionDeclaration _ [equation]) = unguardedEquationBody equation
 

--- a/src/Language/Mulang/Ast.hs
+++ b/src/Language/Mulang/Ast.hs
@@ -48,7 +48,7 @@ data EquationBody
 data Expression
         = TypeAliasDeclaration Identifier                    -- ^ Functional programming type alias. Only the type alias identifier is parsed
         | RecordDeclaration Identifier                       -- ^ Imperative / Functional programming struct declaration. Only the record name is parsed
-        | TypeSignature Identifier                           -- ^ Generic type signature for a computation. Only the target name of the computation is parsed
+        | TypeSignature Identifier [Identifier]              -- ^ Generic type signature for a computation. Only the target name of the computation is parsed
         | EntryPoint Expression
         | FunctionDeclaration Identifier [Equation]          -- ^ Functional / Imperative programming function declaration. It is is composed by an identifier and one or more equations
         | ProcedureDeclaration Identifier [Equation]         -- ^ Imperative programming procedure declaration. It is composed by a name and one or more equations

--- a/src/Language/Mulang/Cli/Code.hs
+++ b/src/Language/Mulang/Cli/Code.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE DeriveGeneric #-}
 
-module        Language.Mulang.Cli.Code where
+module        Language.Mulang.Cli.Code (
+  parseCode,
+  Code(..),
+  Language(..)) where
 
 import        GHC.Generics
 
@@ -14,19 +17,17 @@ import        Language.Mulang.Parsers.Prolog (parseProlog)
 import        Language.Mulang.Parsers.Gobstones (parseGobstones)
 import        Text.Read
 
-
 data Code = Code {
-    language :: Language,
-    content :: String
+  language :: Language,
+  content :: String
 } deriving (Show, Eq, Generic)
 
-data Language
-      =  Mulang
-      |  Json
-      |  JavaScript
-      |  Prolog
-      |  GobstonesAst
-      |  Haskell deriving (Show, Eq, Generic)
+data Language =  Mulang
+              |  Json
+              |  JavaScript
+              |  Prolog
+              |  GobstonesAst
+              |  Haskell deriving (Show, Eq, Generic)
 
 instance FromJSON Code
 instance FromJSON Language

--- a/src/Language/Mulang/Cli/Code.hs
+++ b/src/Language/Mulang/Cli/Code.hs
@@ -35,7 +35,6 @@ instance FromJSON Language
 instance ToJSON Code
 instance ToJSON Language
 
-
 parseCode :: Code -> Maybe Expression
 parseCode (Code Mulang content)         = readMaybe content
 parseCode (Code Json content)           = parseJson content

--- a/src/Language/Mulang/Cli/Code.hs
+++ b/src/Language/Mulang/Cli/Code.hs
@@ -14,7 +14,7 @@ import        Language.Mulang.Parsers.Json
 import        Language.Mulang.Parsers.Haskell
 import        Language.Mulang.Parsers.JavaScript (parseJavaScript)
 import        Language.Mulang.Parsers.Prolog (parseProlog)
-import        Language.Mulang.Parsers.Gobstones (parseGobstones)
+import        Language.Mulang.Parsers.Gobstones (parseGobstones, parseGobstonesAst)
 import        Text.Read
 
 data Code = Code {
@@ -27,6 +27,7 @@ data Language =  Mulang
               |  JavaScript
               |  Prolog
               |  GobstonesAst
+              |  Gobstones
               |  Haskell deriving (Show, Eq, Generic)
 
 instance FromJSON Code
@@ -41,4 +42,5 @@ parseCode (Code Json content)           = parseJson content
 parseCode (Code Haskell content)        = parseHaskell content
 parseCode (Code JavaScript content)     = parseJavaScript content
 parseCode (Code Prolog content)         = parseProlog content
-parseCode (Code GobstonesAst content)   = parseGobstones content
+parseCode (Code Gobstones content)   = parseGobstones content
+parseCode (Code GobstonesAst content)   = parseGobstonesAst content

--- a/src/Language/Mulang/Cli/Compiler.hs
+++ b/src/Language/Mulang/Cli/Compiler.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE DeriveGeneric #-}
 
 module Language.Mulang.Cli.Compiler(
-    compile,
-    Expectation(..),
-    BindingPattern(..)) where
+  compile,
+  Expectation(..),
+  BindingPattern(..)) where
 
 import GHC.Generics
 import Data.Aeson

--- a/src/Language/Mulang/Cli/Compiler.hs
+++ b/src/Language/Mulang/Cli/Compiler.hs
@@ -11,7 +11,9 @@ import Language.Mulang
 import Data.Maybe (fromMaybe)
 import Data.List.Split (splitOn)
 
-data BindingPattern = Named String | Like String | Anyone deriving (Show, Eq, Generic)
+data BindingPattern = Named String
+                    | Like String
+                    | Anyone deriving (Show, Eq, Generic)
 
 data Expectation =  Advanced {
                       subject :: [String] ,

--- a/src/Language/Mulang/Cli/Interpreter.hs
+++ b/src/Language/Mulang/Cli/Interpreter.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 
 module Language.Mulang.Cli.Interpreter (
+            newSample,
+            expectationsSample,
             evaluate,
             Input(..),
             Output(..),
+            SignatureGeneration,
             Expectation(..),
             ExpectationResult(..)) where
 
@@ -16,16 +19,21 @@ import Data.Aeson
 import Language.Mulang
 import Language.Mulang.Inspector.Generic.Smell
 
+
 data Input = Input {
   code :: Code,
-  expectations :: [Expectation]
+  expectations :: [Expectation],
+  signatureGeneration :: SignatureGeneration
 } deriving (Show, Eq, Generic)
-
 
 data Output = Output {
   results :: [ExpectationResult],
   smells :: [Expectation]
 }  deriving (Show, Eq, Generic)
+
+data SignatureGeneration = NoSignatureGeneration
+                         | StructuredSignatureGeneration
+                         | CodeSignatureGeneration deriving (Show, Eq, Generic)
 
 data ExpectationResult = ExpectationResult {
   expectation :: Expectation,
@@ -35,13 +43,21 @@ data ExpectationResult = ExpectationResult {
 instance FromJSON Input
 instance FromJSON Output
 instance FromJSON ExpectationResult
+instance FromJSON SignatureGeneration
 
 instance ToJSON Output
 instance ToJSON Input
 instance ToJSON ExpectationResult
+instance ToJSON SignatureGeneration
+
+newSample :: Code -> Input
+newSample code = Input code [] NoSignatureGeneration
+
+expectationsSample :: Code -> [Expectation] -> Input
+expectationsSample code es = (newSample code) { expectations = es }
 
 evaluate :: Input -> Output
-evaluate (Input code expectations)
+evaluate (Input code expectations _)
       | Just ast <- parseCode code = Output (evaluateExpectations expectations ast) (detectSmells ast)
       | otherwise = Output [] []
 

--- a/src/Language/Mulang/Cli/Interpreter.hs
+++ b/src/Language/Mulang/Cli/Interpreter.hs
@@ -27,12 +27,12 @@ data Input = Input {
 } deriving (Show, Eq, Generic)
 
 data Output = Output {
-  results :: ExpectationAnalysysResult,
+  results :: ExpectationAnalysisResult,
   smells :: SmellAnalysysResult,
   signatures :: SignatureAnalysysResult
 }  deriving (Show, Eq, Generic)
 
-type ExpectationAnalysysResult = [ExpectationResult]
+type ExpectationAnalysisResult = [ExpectationResult]
 type SmellAnalysysResult = [Expectation]
 type SignatureAnalysysResult = [String]
 

--- a/src/Language/Mulang/Cli/Interpreter.hs
+++ b/src/Language/Mulang/Cli/Interpreter.hs
@@ -1,14 +1,14 @@
 {-# LANGUAGE DeriveGeneric #-}
 
 module Language.Mulang.Cli.Interpreter (
-            newSample,
-            expectationsSample,
-            evaluate,
-            Input(..),
-            Output(..),
-            SignatureGeneration,
-            Expectation(..),
-            ExpectationResult(..)) where
+  newSample,
+  expectationsSample,
+  evaluate,
+  Input(..),
+  Output(..),
+  SignatureGeneration,
+  Expectation(..),
+  ExpectationResult(..)) where
 
 import Language.Mulang.Cli.Code
 import Language.Mulang.Cli.Compiler
@@ -18,7 +18,6 @@ import Data.Aeson
 
 import Language.Mulang
 import Language.Mulang.Inspector.Generic.Smell
-
 
 data Input = Input {
   code :: Code,

--- a/src/Language/Mulang/Explorer.hs
+++ b/src/Language/Mulang/Explorer.hs
@@ -104,7 +104,7 @@ extractReference _               = Nothing
 
 
 extractDeclaration :: Expression -> Maybe (Binding, Expression)
-extractDeclaration e@(TypeSignature n)         = Just (n, e)
+extractDeclaration e@(TypeSignature n _)       = Just (n, e)
 extractDeclaration e@(TypeAliasDeclaration n ) = Just (n, e)
 extractDeclaration e@(VariableDeclaration n _) = Just (n, e)
 extractDeclaration e@(FunctionDeclaration n _) = Just (n, e)

--- a/src/Language/Mulang/Inspector/Generic.hs
+++ b/src/Language/Mulang/Inspector/Generic.hs
@@ -113,8 +113,6 @@ usesAnonymousVariable = containsExpression f
         equationContainsWildcard = any (paramsContainsWildcard . equationParams)
         paramsContainsWildcard = any isOrContainsWildcard
 
-        equationParams (Equation p _) = p
-
         isOrContainsWildcard (InfixApplicationPattern p1 _ p2) = any isOrContainsWildcard [p1, p2]
         isOrContainsWildcard (ApplicationPattern _ ps)         = any isOrContainsWildcard ps
         isOrContainsWildcard (TuplePattern ps)                 = any isOrContainsWildcard ps

--- a/src/Language/Mulang/Inspector/Generic.hs
+++ b/src/Language/Mulang/Inspector/Generic.hs
@@ -44,8 +44,8 @@ usesIf = containsExpression f
 -- | Inspection that tells whether a top level binding exists
 declares :: BindingPredicate -> Inspection
 declares = containsDeclaration f
-  where f (TypeSignature _) = False
-        f _                 = True
+  where f (TypeSignature _ _) = False
+        f _                   = True
 
 -- | Inspection that tells whether an expression is direct recursive
 declaresRecursively :: BindingPredicate -> Inspection
@@ -96,8 +96,8 @@ declaresTypeAlias = containsDeclaration f
 
 declaresTypeSignature :: BindingPredicate -> Inspection
 declaresTypeSignature = containsDeclaration f
-  where f (TypeSignature _)  = True
-        f _                  = False
+  where f (TypeSignature _ _)  = True
+        f _                    = False
 
 
 usesAnonymousVariable :: Inspection

--- a/src/Language/Mulang/Inspector/Generic/Duplication.hs
+++ b/src/Language/Mulang/Inspector/Generic/Duplication.hs
@@ -42,14 +42,6 @@ hash f@(ProcedureDeclaration _ _)  = 17 * (37 + hash (simpleProcedureBody f))
 hash (Sequence es)                 = 19 * (37 + positionalHash es)
 hash _                             = 1
 
-simpleProcedureBody :: Expression -> Expression
-simpleProcedureBody (ProcedureDeclaration _ [equation]) = equationUnguardedBody equation
-
-simpleFunctionBody :: Expression -> Expression
-simpleFunctionBody (FunctionDeclaration _ [equation]) = equationUnguardedBody equation
-equationUnguardedBody (Equation _ (UnguardedBody body)) = body
-
-
 positionalHash :: [Expression] -> Int
 positionalHash = sum . zipWith hashElement [1..] . reverse
         where

--- a/src/Language/Mulang/Parsers/Haskell.hs
+++ b/src/Language/Mulang/Parsers/Haskell.hs
@@ -31,7 +31,7 @@ mu (HsModule _ _ _ _ decls) = compact (concatMap muDecls decls)
 
     muDecls (HsTypeDecl _ name _ _)      = [TypeAliasDeclaration (muName name)]
     muDecls (HsDataDecl _ _ name _ _ _ ) = [RecordDeclaration (muName name)]
-    muDecls (HsTypeSig _ names _) = map (\name -> TypeSignature (muName name)) names
+    muDecls (HsTypeSig _ names (HsQualType _ t)) = map (\name -> TypeSignature (muName name) (muType t)) names
     muDecls (HsFunBind equations) | (HsMatch _ name _ _ _) <- head equations =
                                         [FunctionDeclaration (muName name) (map muEquation equations)]
     muDecls (HsPatBind _ (HsPVar name) (HsUnGuardedRhs exp) _) = [VariableDeclaration (muName name) (muExp exp)]
@@ -117,3 +117,7 @@ mu (HsModule _ _ _ _ decls) = compact (concatMap muDecls decls)
 
     muStmt (HsGenerator _ pat exp) = MuGenerator (muPat pat) (muExp exp)
     muStmt (HsQualifier exp) = MuQualifier (muExp exp)
+
+    muType (HsTyFun i o)  = muType i ++ muType o
+    muType (HsTyCon name) = [muQName name]
+    muType t              = [show t]

--- a/src/Language/Mulang/Parsers/Haskell.hs
+++ b/src/Language/Mulang/Parsers/Haskell.hs
@@ -31,7 +31,7 @@ mu (HsModule _ _ _ _ decls) = compact (concatMap muDecls decls)
 
     muDecls (HsTypeDecl _ name _ _)      = [TypeAliasDeclaration (muName name)]
     muDecls (HsDataDecl _ _ name _ _ _ ) = [RecordDeclaration (muName name)]
-    muDecls (HsTypeSig _ names (HsQualType _ t)) = map (\name -> TypeSignature (muName name) (muType t)) names
+    muDecls (HsTypeSig _ names (HsQualType _ t)) = map (\name -> TypeSignature (muName name) (muTopType t)) names
     muDecls (HsFunBind equations) | (HsMatch _ name _ _ _) <- head equations =
                                         [FunctionDeclaration (muName name) (map muEquation equations)]
     muDecls (HsPatBind _ (HsPVar name) (HsUnGuardedRhs exp) _) = [VariableDeclaration (muName name) (muExp exp)]
@@ -118,6 +118,13 @@ mu (HsModule _ _ _ _ decls) = compact (concatMap muDecls decls)
     muStmt (HsGenerator _ pat exp) = MuGenerator (muPat pat) (muExp exp)
     muStmt (HsQualifier exp) = MuQualifier (muExp exp)
 
-    muType (HsTyFun i o)  = muType i ++ muType o
-    muType (HsTyCon name) = [muQName name]
-    muType t              = [show t]
+
+    muTopType (HsTyFun i o) = muType i : muTopType o
+    muTopType t             = [muType t]
+
+    muType (HsTyFun i o)                              = muType i ++ " -> " ++ muType o
+    muType (HsTyCon name)                             = muQName name
+    muType (HsTyVar name)                             = muName name
+    muType (HsTyTuple ts)                             = "(" ++ (intercalate ", " . map muType $ ts) ++ ")"
+    muType (HsTyApp (HsTyCon (Special HsListCon)) t2) = "[" ++ muType t2 ++ "]"
+    muType (HsTyApp t1 t2)                            = muType t1 ++ " " ++ muType t2

--- a/src/Language/Mulang/Signature.hs
+++ b/src/Language/Mulang/Signature.hs
@@ -61,7 +61,7 @@ codeSignaturesOf = map code . signaturesOf
 code :: Signature -> String
 code (AritySignature name arity) = name ++ "/" ++ show arity
 code (NamedSignature name names) = name ++ "(" ++ (intercalate ", " . zipWith makeName [1..] $ names) ++ ")"
-code (TypedSignature name types) = name ++ "::" ++ (intercalate " -> " types)
+code (TypedSignature name types) = name ++ " :: " ++ (intercalate " -> " types)
 
 makeName :: Int -> Maybe Binding -> String
 makeName _        (Just name) = name

--- a/src/Language/Mulang/Signature.hs
+++ b/src/Language/Mulang/Signature.hs
@@ -1,0 +1,27 @@
+module Language.Mulang.Signature (
+  arity,
+  name,
+  paramterNames,
+  Signature(..)) where
+
+import Language.Mulang.Binding
+
+data Signature = AritySignature Binding Int
+               | TypedSignature Binding [Binding]
+               | NamedSignature Binding [Maybe Binding] deriving (Show, Eq)
+
+
+arity :: Signature -> Int
+arity (AritySignature _ a) = a
+arity (TypedSignature _ ps) = length ps
+arity (NamedSignature _ ps) = length ps
+
+name :: Signature -> Binding
+name (AritySignature n _) = n
+name (TypedSignature n _) = n
+name (NamedSignature n _) = n
+
+paramterNames :: Signature -> [Maybe Binding]
+paramterNames (AritySignature _ arity) = replicate arity Nothing
+paramterNames (TypedSignature _ types) = map (const Nothing) types
+paramterNames (NamedSignature _ names) = names

--- a/src/Language/Mulang/Signature.hs
+++ b/src/Language/Mulang/Signature.hs
@@ -1,10 +1,20 @@
 module Language.Mulang.Signature (
   arity,
   name,
+  code,
   paramterNames,
+  signatureOf,
+  signaturesOf,
+  codeSignaturesOf,
   Signature(..)) where
 
 import Language.Mulang.Binding
+import Language.Mulang.Ast
+import Language.Mulang.Explorer (declarationsOf)
+
+import           Data.List (transpose, intercalate, nub)
+import           Data.Maybe (mapMaybe)
+import           Control.Monad (msum)
 
 data Signature = AritySignature Binding Int
                | TypedSignature Binding [Binding]
@@ -25,3 +35,34 @@ paramterNames :: Signature -> [Maybe Binding]
 paramterNames (AritySignature _ arity) = replicate arity Nothing
 paramterNames (TypedSignature _ types) = map (const Nothing) types
 paramterNames (NamedSignature _ names) = names
+
+signaturesOf :: Expression -> [Signature]
+signaturesOf = nub . mapMaybe (signatureOf.snd) . declarationsOf
+
+signatureOf :: Expression -> Maybe Signature
+signatureOf (FunctionDeclaration name equations)  = Just $ NamedSignature name (parameterNamesOf equations)
+signatureOf (ProcedureDeclaration name equations) = Just $ NamedSignature name (parameterNamesOf equations)
+signatureOf (RuleDeclaration name args _)         = Just $ AritySignature name (length args)
+signatureOf (FactDeclaration name args)           = Just $ AritySignature name (length args)
+signatureOf (TypeSignature name args)             = Just $ TypedSignature name args
+signatureOf (VariableDeclaration name _)          = Just $ AritySignature name 0
+signatureOf _                                     = Nothing
+
+parameterNamesOf :: [Equation] -> [Maybe Binding]
+parameterNamesOf = map msum . transpose . map (map parameterNameOf . equationParams)
+
+parameterNameOf :: Pattern -> Maybe Binding
+parameterNameOf (VariablePattern v) = Just v
+parameterNameOf _                   = Nothing
+
+codeSignaturesOf :: Expression -> [String]
+codeSignaturesOf = map code . signaturesOf
+
+code :: Signature -> String
+code (AritySignature name arity) = name ++ "/" ++ show arity
+code (NamedSignature name names) = name ++ "(" ++ (intercalate ", " . zipWith makeName [1..] $ names) ++ ")"
+code (TypedSignature name types) = name ++ "::" ++ (intercalate " -> " types)
+
+makeName :: Int -> Maybe Binding -> String
+makeName _        (Just name) = name
+makeName position Nothing     = "arg" ++ show position

--- a/src/Language/Mulang/Signature.hs
+++ b/src/Language/Mulang/Signature.hs
@@ -2,7 +2,7 @@ module Language.Mulang.Signature (
   arity,
   name,
   code,
-  paramterNames,
+  parameterNames,
   signatureOf,
   signaturesOf,
   codeSignaturesOf,
@@ -31,10 +31,10 @@ name (AritySignature n _) = n
 name (TypedSignature n _) = n
 name (NamedSignature n _) = n
 
-paramterNames :: Signature -> [Maybe Binding]
-paramterNames (AritySignature _ arity) = replicate arity Nothing
-paramterNames (TypedSignature _ types) = map (const Nothing) types
-paramterNames (NamedSignature _ names) = names
+parameterNames :: Signature -> [Maybe Binding]
+parameterNames (AritySignature _ arity) = replicate arity Nothing
+parameterNames (TypedSignature _ types) = map (const Nothing) types
+parameterNames (NamedSignature _ names) = names
 
 signaturesOf :: Expression -> [Signature]
 signaturesOf = nub . mapMaybe (signatureOf.snd) . declarationsOf


### PR DESCRIPTION
Fixes #57

This PR adds initial support for signature analysis. Current signature format is hardcoded, it resembles haskell, prolog and js code signatures, but it does not intend to produce language-sensitive signatures. It may be addressed in a future PR. 
 
Some samples: 

## JavaScript

```bash
$ mulang '
{
   "code" : {
      "content" : "function foo(x, y) { return x + y; }\nfunction bar(z) { return z * 2; }",
      "language" : "JavaScript"
   },
   "expectations" : [],
   "analyseSignatures" : true
}' | json_pp
{
   "smells" : [],
   "results" : [],
   "signatures" : [
      "foo(x, y)",
      "bar(z)"
   ]
}
```

## Prolog

```bash
$ mulang '
{
   "code" : {
      "content" : "foo(X, Y) :- m(X), b(Y).",
      "language" : "Prolog"
   },
   "expectations" : [],
   "analyseSignatures" : true
}' | json_pp
{
   "results" : [],
   "signatures" : [
      "foo/2"
   ],
   "smells" : []
}
```

## Gobstones

```bash
mulang '
{
   "code" : {
      "content" : "procedure MoverN(direccion, distancia) { }
                   function estaVacioAl(direccion) { return (False) }",
      "language" : "Gobstones"
   },
   "expectations" : [],
   "analyseSignatures" : true
}' | json_pp
{
   "results" : [],
   "smells" : [],
   "signatures" : [
      "MoverN(direccion, distancia)",
      "estaVacioAl(direccion)"
   ]
}
```

## Haskell

Notice that Haskell will produce two signatures - one typed and one named - if there is a type declaration. 

```bash
$ mulang '
{
   "code" : {
      "content" : "x :: Int\nx = 0\ny :: Int->Int->Int\ny 1 z = 1\ny x _ = 2 * x\nz _ = 9",
      "language" : "Haskell"
   },
   "expectations" : [],
   "analyseSignatures" : true
}' | json_pp
{
   "results" : [],
   "signatures" : [
      "x :: Int",
      "x/0",
      "y :: Int -> Int -> Int",
      "y(x, z)",
      "z(arg1)"
   ],
   "smells" : []
}
```