### PR TITLE
Perform domain smells analysis only on main expressions

### DIFF
--- a/src/Language/Mulang/Analyzer.hs
+++ b/src/Language/Mulang/Analyzer.hs
@@ -6,6 +6,7 @@ module Language.Mulang.Analyzer (
   emptyAnalysisSpec,
 
   emptyAnalysis,
+  domainLanguageAnalysis,
   expectationsAnalysis,
   smellsAnalysis,
   signaturesAnalysis,
@@ -36,6 +37,9 @@ emptyAnalysisSpec = AnalysisSpec [] noSmells Nothing Nothing
 
 emptyAnalysis :: Sample -> Analysis
 emptyAnalysis code = Analysis code emptyAnalysisSpec
+
+domainLanguageAnalysis :: Sample -> DomainLanguage -> Analysis
+domainLanguageAnalysis code domainLanguage = Analysis code (emptyAnalysisSpec { domainLanguage = Just domainLanguage, smellsSet = allSmells })
 
 expectationsAnalysis :: Sample -> [Expectation] -> Analysis
 expectationsAnalysis code es = Analysis code (emptyAnalysisSpec { expectations = es })

--- a/src/Language/Mulang/DomainLanguage.hs
+++ b/src/Language/Mulang/DomainLanguage.hs
@@ -6,7 +6,7 @@ module Language.Mulang.DomainLanguage (
 
 import Language.Mulang.Inspector (Inspection)
 import Language.Mulang.Ast (Expression)
-import Language.Mulang.Generator (declaredIdentifiers)
+import Language.Mulang.Generator (mainDeclaredIdentifiers)
 
 import Text.Dictionary (Dictionary, exists)
 
@@ -22,7 +22,7 @@ data DomainLanguage = DomainLanguage {
 type DomainLanguageInspection = DomainLanguage -> Inspection
 
 hasTooShortIdentifiers :: DomainLanguageInspection
-hasTooShortIdentifiers language = any isShort . declaredIdentifiers
+hasTooShortIdentifiers language = any isShort . mainDeclaredIdentifiers
   where isShort identifier = length identifier < (minimumIdentifierSize language) && notJargonOf identifier language
 
 hasMisspelledIdentifiers :: DomainLanguageInspection
@@ -32,10 +32,10 @@ hasMisspelledIdentifiers language = any isMisspelled  . wordsOf language
 
 hasWrongCaseIdentifiers :: DomainLanguageInspection
 hasWrongCaseIdentifiers (DomainLanguage _ style _ _)
-  = any (not . canTokenize style) . declaredIdentifiers
+  = any (not . canTokenize style) . mainDeclaredIdentifiers
 
 wordsOf :: DomainLanguage -> Expression -> [String]
-wordsOf (DomainLanguage _ style _ _) = concatMap (tokenize style) . declaredIdentifiers
+wordsOf (DomainLanguage _ style _ _) = concatMap (tokenize style) . mainDeclaredIdentifiers
 
 emptyDictionary = null . dictionary
 

--- a/src/Language/Mulang/Generator.hs
+++ b/src/Language/Mulang/Generator.hs
@@ -3,6 +3,7 @@ module Language.Mulang.Generator (
   declarations,
   declarationsOf,
   declaredIdentifiers,
+  mainDeclaredIdentifiers,
   equationBodies,
   expressions,
   referencedIdentifiers,
@@ -99,6 +100,10 @@ transitiveReferencedIdentifiers identifier code =  expand (concatMap referencedI
 -- For example, in 'f x = g x where x = y', it returns 'f' and 'x'
 declaredIdentifiers :: Generator Identifier
 declaredIdentifiers = map fst . declarations
+
+mainDeclaredIdentifiers :: Generator Identifier
+mainDeclaredIdentifiers (Sequence _) = []
+mainDeclaredIdentifiers expression   = take 1 . declaredIdentifiers $ expression
 
 -- | Returns all the body equations of functions, procedures and methods
 equationBodies :: Generator EquationBody


### PR DESCRIPTION
Domain Language analysis, since it is performed over identifiers
and not whole expressions, may arise confusing results if evaluated
with normal 'is-or-contains' semantics.