### PR TITLE
Add empty if branches smell

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@ The power of Mulang is grounded on more than 70 different kind of inspections:
 | `doesTypeTest`                    |
 | `hasAssignmentReturn`             |
 | `hasCodeDuplication`              |  any               | has the given code simple literal code duplication?
+| `hasEmptyIfBranches`              |  any               | has the given code an empty if branch?
 | `hasLongParameterList`            |  any               | does a given method/function/predicate take too many parameters?
 | `hasMisspelledIdentifiers`        |  any               | an identifier is not a domain language dictionary's word and not part of its jargon
 | `hasRedundantBooleanComparison`   |

--- a/spec/SmellSpec.hs
+++ b/spec/SmellSpec.hs
@@ -235,3 +235,10 @@ spec = do
 
     it "is False when both are overriden" $ do
       overridesEqualOrHashButNotBoth (java "public class A{ public void equals(){}\npublic void hashCode(){} }") `shouldBe` False
+
+  describe "hasEmptyIfBranches" $ do
+    it "is True when if branch is empty but else isn't" $ do
+      hasEmptyIfBranches (javaStatement "if(true) { } else { i++; }") `shouldBe` True
+
+    it "is False when if branch is not empty" $ do
+      hasEmptyIfBranches (javaStatement "if(true) { j++; } else { i++; }") `shouldBe` False

--- a/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
+++ b/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
@@ -52,6 +52,7 @@ detectionFor "DoesNullTest"                    = simple doesNullTest
 detectionFor "DoesTypeTest"                    = simple doesTypeTest
 detectionFor "HasAssignmentReturn"             = simple hasAssignmentReturn
 detectionFor "HasCodeDuplication"              = unsupported
+detectionFor "HasEmptyIfBranches"              = simple hasEmptyIfBranches
 detectionFor "HasLongParameterList"            = simple hasLongParameterList
 detectionFor "HasMisspelledIdentifiers"        = withLanguage hasMisspelledIdentifiers
 detectionFor "HasMisspelledBindings"           = withLanguage hasMisspelledIdentifiers

--- a/src/Language/Mulang/Inspector/Generic/Smell.hs
+++ b/src/Language/Mulang/Inspector/Generic/Smell.hs
@@ -6,6 +6,7 @@ module Language.Mulang.Inspector.Generic.Smell (
   hasRedundantParameter,
   hasRedundantLocalVariableReturn,
   hasAssignmentReturn,
+  hasEmptyIfBranches,
   doesNullTest,
   doesTypeTest,
   isLongCode,
@@ -140,3 +141,8 @@ overridesEqualOrHashButNotBoth = containsExpression f
         
         isHash (HashMethod _) = True
         isHash _ = False
+
+hasEmptyIfBranches :: Inspection
+hasEmptyIfBranches = containsExpression f
+  where f (If _ MuNull elseBranch) = elseBranch /= MuNull
+        f _                        = False


### PR DESCRIPTION
Fixes #66

It is somewhat limited since it can actually only detect this case:

if(condition){

} else {
  something();
}

Detecting an empty else is impossible without further distinguishing between the lack of an else body and the lack of an else altogether.