### PR TITLE
Force older version of inflections library

### DIFF
--- a/mulang.cabal
+++ b/mulang.cabal
@@ -75,7 +75,7 @@ library
     language-java             ,
     language-javascript       ,
     aeson                     ,
-    inflections               ,
+    inflections               <= 0.2.0.1,
     parsec                    ,
     ParsecTools               ,
     split                     ,


### PR DESCRIPTION
It appears that the inflections API changed somewhat as of 0.3.0.0, and while the stack lts-7.24 resolver gives the right version, building with cabal alone may fail (and this may be why hackage lists mulang as failing to build).