### PR TITLE
Issue #177 haskell literal patterns are ignored

### DIFF
--- a/spec/HaskellSpec.hs
+++ b/spec/HaskellSpec.hs
@@ -7,6 +7,15 @@ import           Language.Mulang.Parsers.Haskell
 spec :: Spec
 spec = do
   describe "parse" $ do
+    it "parses literal character patterns" $ do
+      hs "f 'a' = 1" `shouldBe` (Function "f" [Equation [LiteralPattern "'a'"] (UnguardedBody (Return (MuNumber 1.0)))])
+
+    it "parses literal string patterns" $ do
+      hs "f \"hello world\" = 1" `shouldBe` (Function "f" [Equation [LiteralPattern "\"hello world\""] (UnguardedBody (Return (MuNumber 1.0)))])
+
+    it "parses literal number patterns" $ do
+      hs "f 1 = 1" `shouldBe` (Function "f" [Equation [LiteralPattern "1"] (UnguardedBody (Return (MuNumber 1.0)))])
+
     it "parses left infix partial application" $ do
       hs "f = (1+)" `shouldBe` Variable "f" (Application (Reference "+") [MuNumber 1.0])
 

--- a/src/Language/Mulang/Ast.hs
+++ b/src/Language/Mulang/Ast.hs
@@ -70,7 +70,7 @@ data Type
         | ConstrainedType [Identifier]
         -- ^ constrained type, with just type constraints.
         -- Usefull for modelling classes and interfaces types
-        | OtherType (Maybe String) (Maybe Type)
+        | OtherType (Maybe Code) (Maybe Type)
         -- ^ unrecognized type, with optional code and nested type
         deriving (Eq, Show, Read, Generic)
 
@@ -164,7 +164,7 @@ data Expression
     -- ^ Imperative / OOP programming c-style for loop
     | Sequence [Expression]
     -- ^ Generic sequence of statements
-    | Other (Maybe String) (Maybe Expression)
+    | Other (Maybe Code) (Maybe Expression)
     -- ^ Unrecognized expression, with optional description and body
     | Equal
     | NotEqual
@@ -190,13 +190,13 @@ data Expression
 -- | Mulang Patterns are not expressions, but are aimed to match them.
 -- | They are modeled after Haskell, Prolog, Elixir, Scala and Erlang patterns
 data Pattern
-    = VariablePattern String
+    = VariablePattern Identifier
     -- ^ variable pattern like @X@
-    | LiteralPattern String
+    | LiteralPattern Code
     -- ^ literal constant pattern like @4@
-    | InfixApplicationPattern Pattern String Pattern
+    | InfixApplicationPattern Pattern Identifier Pattern
     -- ^ infix application pattern like @4:X@
-    | ApplicationPattern String [Pattern]
+    | ApplicationPattern Identifier [Pattern]
     -- ^ prefix application pattern like @f _@
     | TuplePattern [Pattern]
     -- ^ tuple pattern like @(3, _)@
@@ -210,7 +210,7 @@ data Pattern
     | WildcardPattern
     -- ^ wildcard pattern @_@
     | UnionPattern [Pattern]
-    | OtherPattern (Maybe String) (Maybe Pattern)
+    | OtherPattern (Maybe Code) (Maybe Pattern)
     -- ^ Other unrecognized pattern with optional code and nested pattern
   deriving (Eq, Show, Read, Generic)
 

--- a/src/Language/Mulang/Parsers/Haskell.hs
+++ b/src/Language/Mulang/Parsers/Haskell.hs
@@ -6,6 +6,7 @@ import Language.Mulang.Parsers
 
 import Language.Haskell.Syntax
 import Language.Haskell.Parser
+import Language.Haskell.Pretty (prettyPrint)
 
 import Data.List (intercalate)
 
@@ -50,7 +51,7 @@ mu (HsModule _ _ _ _ decls) = compact (concatMap muDecls decls)
     muBody = Return . muExp
 
     muPat (HsPVar name) = VariablePattern (muName name)
-    muPat (HsPLit _) = LiteralPattern ""
+    muPat (HsPLit literal) = LiteralPattern (prettyPrint literal)
     muPat (HsPInfixApp e1 name e2) = InfixApplicationPattern (muPat e1) (muQName name) (muPat e2)
     muPat (HsPApp name elements) = ApplicationPattern (muQName name) (map muPat elements)
     muPat (HsPTuple elements) = TuplePattern (map muPat elements)


### PR DESCRIPTION
Fixes #177 

The issue was actually only with literal patterns. In the future, we should refactor the `LiteralPattern` element to actually accept and expression instead of just code