### PR TITLE
Feature reordering

### DIFF
--- a/spec/AnalysisJsonSpec.hs
+++ b/spec/AnalysisJsonSpec.hs
@@ -125,7 +125,7 @@ spec = describe "AnalysisJson" $ do
       "expectations" : []
    }
 }|]
-    let analysis = Analysis (MulangSample (Sequence [Variable "x" (MuNumber 1), Variable "y" (MuNumber 2)]))
+    let analysis = Analysis (MulangSample (Sequence [Variable "x" (MuNumber 1), Variable "y" (MuNumber 2)]) Nothing)
                             (emptyAnalysisSpec { signatureAnalysisType = Just (StyledSignatures HaskellStyle) })
 
     run json `shouldBe` analysis

--- a/spec/ExpectationsAnalyzerSpec.hs
+++ b/spec/ExpectationsAnalyzerSpec.hs
@@ -7,7 +7,7 @@ import           Test.Hspec
 result expectationsResults smellResults = AnalysisCompleted expectationsResults smellResults [] Nothing
 
 run language content expectations = analyse (expectationsAnalysis (CodeSample language content) expectations)
-runAst ast expectations = analyse (expectationsAnalysis (MulangSample ast) expectations)
+runAst ast expectations = analyse (expectationsAnalysis (MulangSample ast Nothing) expectations)
 
 passed e = ExpectationResult e True
 failed e = ExpectationResult e False

--- a/spec/NormalizationSpec.hs
+++ b/spec/NormalizationSpec.hs
@@ -1,0 +1,17 @@
+module NormalizationSpec (spec) where
+
+  import           Test.Hspec
+  import           Language.Mulang.Parsers.Haskell (hs)
+  import           Language.Mulang.Parsers.JavaScript (js)
+
+  spec :: Spec
+  spec = do
+    describe "sorts declarations by default" $ do
+      it "sorts declarations on haskell" $ do
+        hs "f 1 = 1\ng 2 = 2" `shouldBe` hs "g 2 = 2\nf 1 = 1"
+
+      it "sorts declarations on javascript if there are only declarations" $ do
+        js "function f() {} function g() {}" `shouldBe` js "function g() {} function f() {}"
+
+      it "doesn't sort declarations on javascript if there are also statements" $ do
+        js "function f() {}; var x = 2; function g() {}" `shouldNotBe` js "function g() {}; var x = 2; function f() {}"

--- a/spec/NormalizationSpec.hs
+++ b/spec/NormalizationSpec.hs
@@ -1,16 +1,23 @@
 module NormalizationSpec (spec) where
 
   import           Test.Hspec
+  import           Language.Mulang.Parsers.Java (java)
   import           Language.Mulang.Parsers.Haskell (hs)
   import           Language.Mulang.Parsers.JavaScript (js)
 
   spec :: Spec
   spec = do
     describe "sorts declarations by default" $ do
-      it "sorts declarations on haskell" $ do
+      it "sorts classes on Java" $ do
+        java "class Foo {} class Bar {}" `shouldBe` java "class Bar {} class Foo {}"
+
+      it "sorts functions on haskell" $ do
         hs "f 1 = 1\ng 2 = 2" `shouldBe` hs "g 2 = 2\nf 1 = 1"
 
-      it "sorts declarations on javascript if there are only declarations" $ do
+      it "sorts declarations on haskell even when there are variables" $ do
+        hs "n = 1\nf 1 = 1\ng 2 = 2" `shouldBe` hs "g 2 = 2\nf 1 = 1\nn = 1"
+
+      it "sorts functions on javascript if there are only functions" $ do
         js "function f() {} function g() {}" `shouldBe` js "function g() {} function f() {}"
 
       it "doesn't sort declarations on javascript if there are also statements" $ do

--- a/spec/NormalizationSpec.hs
+++ b/spec/NormalizationSpec.hs
@@ -24,5 +24,8 @@ module NormalizationSpec (spec) where
       it "sorts functions on javascript if there are only functions" $ do
         js "function f() {} function g() {}" `shouldBe` js "function g() {} function f() {}"
 
+      it "doesn't sort functions on javascript if there are duplicates names" $ do
+        js "function f() { return 1 } function g() {} function f() { return 2 }" `shouldNotBe` js "function g() {} function f() { return 2 } function f() { return 1 } "
+
       it "doesn't sort declarations on javascript if there are also statements" $ do
         js "function f() {}; var x = 2; function g() {}" `shouldNotBe` js "function g() {}; var x = 2; function f() {}"

--- a/spec/NormalizationSpec.hs
+++ b/spec/NormalizationSpec.hs
@@ -9,7 +9,7 @@ module NormalizationSpec (spec) where
   spec :: Spec
   spec = do
     describe "sorts declarations by default" $ do
-      it "sorts classes on Python" $ do
+      it "sorts functions on Python" $ do
         py "def foo():\n  return 2\n\ndef bar():\n  return 1\n\n" `shouldBe` py "def bar():\n  return 1\n\ndef foo():\n  return 2\n\n"
 
       it "sorts classes on Java" $ do

--- a/spec/NormalizationSpec.hs
+++ b/spec/NormalizationSpec.hs
@@ -2,12 +2,16 @@ module NormalizationSpec (spec) where
 
   import           Test.Hspec
   import           Language.Mulang.Parsers.Java (java)
+  import           Language.Mulang.Parsers.Python (py)
   import           Language.Mulang.Parsers.Haskell (hs)
   import           Language.Mulang.Parsers.JavaScript (js)
 
   spec :: Spec
   spec = do
     describe "sorts declarations by default" $ do
+      it "sorts classes on Python" $ do
+        py "def foo():\n  return 2\n\ndef bar():\n  return 1\n\n" `shouldBe` py "def bar():\n  return 1\n\ndef foo():\n  return 2\n\n"
+
       it "sorts classes on Java" $ do
         java "class Foo {} class Bar {}" `shouldBe` java "class Bar {} class Foo {}"
 

--- a/spec/SmellsAnalyzerSpec.hs
+++ b/spec/SmellsAnalyzerSpec.hs
@@ -11,7 +11,7 @@ runOnly language content smells = analyse (smellsAnalysis (CodeSample language c
 
 spec = describe "SmellsAnalyzer" $ do
   describe "Using domain language and nested structures" $ do
-    let runRuby sample = analyse (domainLanguageAnalysis (MulangSample sample) (DomainLanguage Nothing (Just RubyCase) (Just 3) Nothing))
+    let runRuby sample = analyse (domainLanguageAnalysis (MulangSample sample Nothing) (DomainLanguage Nothing (Just RubyCase) (Just 3) Nothing))
     it "works with empty set" $ do
       (runRuby (Sequence [
         (Object "Foo_Bar" (Sequence [

--- a/spec/Spec.hs.ghcjs
+++ b/spec/Spec.hs.ghcjs
@@ -1,3 +1,4 @@
+
 module Main where
 
 import Test.Hspec

--- a/src/Language/Mulang/Analyzer/Analysis.hs
+++ b/src/Language/Mulang/Analyzer/Analysis.hs
@@ -20,6 +20,7 @@ module Language.Mulang.Analyzer.Analysis (
 import GHC.Generics
 
 import Language.Mulang.Ast
+import Language.Mulang.Builder (NormalizationOptions)
 
 ---
 -- Common structures
@@ -77,7 +78,7 @@ data SignatureStyle
   | PrologStyle deriving (Show, Eq, Generic)
 
 data Sample
-  = MulangSample { ast :: Expression }
+  = MulangSample { ast :: Expression, normalizationOptions :: Maybe NormalizationOptions }
   | CodeSample { language :: Language, content :: Code } deriving (Show, Eq, Generic)
 
 data Language

--- a/src/Language/Mulang/Analyzer/Analysis/Json.hs
+++ b/src/Language/Mulang/Analyzer/Analysis/Json.hs
@@ -3,6 +3,7 @@ module Language.Mulang.Analyzer.Analysis.Json () where
 import Data.Aeson
 import Language.Mulang
 import Language.Mulang.Analyzer.Analysis
+import Language.Mulang.Builder (NormalizationOptions)
 
 instance FromJSON Analysis
 instance FromJSON AnalysisSpec
@@ -15,6 +16,8 @@ instance FromJSON CaseStyle
 
 instance FromJSON SignatureAnalysisType
 instance FromJSON SignatureStyle
+
+instance FromJSON NormalizationOptions
 
 instance FromJSON Sample
 instance FromJSON Language

--- a/src/Language/Mulang/Analyzer/Analysis/Json.hs
+++ b/src/Language/Mulang/Analyzer/Analysis/Json.hs
@@ -3,7 +3,7 @@ module Language.Mulang.Analyzer.Analysis.Json () where
 import Data.Aeson
 import Language.Mulang
 import Language.Mulang.Analyzer.Analysis
-import Language.Mulang.Builder (NormalizationOptions)
+import Language.Mulang.Builder (NormalizationOptions, SequenceSortMode)
 
 instance FromJSON Analysis
 instance FromJSON AnalysisSpec
@@ -18,6 +18,7 @@ instance FromJSON SignatureAnalysisType
 instance FromJSON SignatureStyle
 
 instance FromJSON NormalizationOptions
+instance FromJSON SequenceSortMode
 
 instance FromJSON Sample
 instance FromJSON Language

--- a/src/Language/Mulang/Analyzer/SampleParser.hs
+++ b/src/Language/Mulang/Analyzer/SampleParser.hs
@@ -9,10 +9,11 @@ import        Language.Mulang.Parsers.Prolog (parseProlog)
 import        Language.Mulang.Parsers.Java (parseJava)
 import        Language.Mulang.Parsers.Python (parsePython)
 import        Language.Mulang.Analyzer.Analysis (Sample(..), Language(..))
+import        Language.Mulang.Builder (normalize, normalizeWith, NormalizationOptions)
 
 parseSample :: Sample -> Either String Expression
 parseSample (CodeSample language content) = (parserFor language) content
-parseSample (MulangSample ast)            = Right ast
+parseSample (MulangSample ast options)    = Right . (normalizerFor options) $ ast
 
 parserFor :: Language -> EitherParser
 parserFor Haskell        = parseHaskell
@@ -20,3 +21,7 @@ parserFor Java           = parseJava
 parserFor JavaScript     = maybeToEither parseJavaScript
 parserFor Prolog         = parseProlog
 parserFor Python         = parsePython
+
+normalizerFor :: (Maybe NormalizationOptions) -> (Expression -> Expression)
+normalizerFor Nothing        = normalize
+normalizerFor (Just options) = normalizeWith options

--- a/src/Language/Mulang/Ast.hs
+++ b/src/Language/Mulang/Ast.hs
@@ -48,12 +48,12 @@ import           Language.Mulang.Identifier (Identifier)
 type Code = String
 
 -- | An equation. See @Function@ and @Procedure@ above
-data Equation = Equation [Pattern] EquationBody deriving (Eq, Show, Read, Generic)
+data Equation = Equation [Pattern] EquationBody deriving (Eq, Show, Read, Generic, Ord)
 
 data EquationBody
         = UnguardedBody Expression
         | GuardedBody  [(Expression, Expression)]
-        deriving (Eq, Show, Read, Generic)
+        deriving (Eq, Show, Read, Generic, Ord)
 
 type SubroutineBody = [Equation]
 
@@ -72,7 +72,7 @@ data Type
         -- Usefull for modelling classes and interfaces types
         | OtherType (Maybe Code) (Maybe Type)
         -- ^ unrecognized type, with optional code and nested type
-        deriving (Eq, Show, Read, Generic)
+        deriving (Eq, Show, Read, Generic, Ord)
 
 -- | Expression is the root element of a Mulang program.
 -- | With the exception of Patterns, nearly everything is an Expression: variable declarations, literals,
@@ -185,7 +185,7 @@ data Expression
     -- ^ Generic symbol/atom literal
     | MuTuple [Expression]
     | MuList [Expression]
-  deriving (Eq, Show, Read, Generic)
+  deriving (Eq, Show, Read, Generic, Ord)
 
 -- | Mulang Patterns are not expressions, but are aimed to match them.
 -- | They are modeled after Haskell, Prolog, Elixir, Scala and Erlang patterns
@@ -212,12 +212,12 @@ data Pattern
     | UnionPattern [Pattern]
     | OtherPattern (Maybe Code) (Maybe Pattern)
     -- ^ Other unrecognized pattern with optional code and nested pattern
-  deriving (Eq, Show, Read, Generic)
+  deriving (Eq, Show, Read, Generic, Ord)
 
 data Statement
   = Generator Pattern Expression
   | Guard Expression
-  deriving (Eq, Show, Read, Generic)
+  deriving (Eq, Show, Read, Generic, Ord)
 
 debug :: Show a => a -> Expression
 debug a = Other (Just (show a)) Nothing

--- a/src/Language/Mulang/Builder.hs
+++ b/src/Language/Mulang/Builder.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveGeneric #-}
+
 module Language.Mulang.Builder (
     compact,
     compactMap,
@@ -5,6 +7,8 @@ module Language.Mulang.Builder (
     normalize,
     normalizeWith,
     NormalizationOptions (..)) where
+
+import           GHC.Generics
 
 import Language.Mulang.Ast
 
@@ -16,7 +20,7 @@ data NormalizationOptions = NormalizationOptions {
   convertObjectLevelVariableIntoAttribute :: Bool,
   sortTopLevelDeclarations :: Bool,
   sortObjectLevelDeclarations :: Bool
-} deriving (Eq, Show)
+} deriving (Eq, Show, Read, Generic)
 
 compactConcatMap :: (a -> [Expression]) -> [a] -> Expression
 compactConcatMap f = compact . concat . map f

--- a/src/Language/Mulang/Builder.hs
+++ b/src/Language/Mulang/Builder.hs
@@ -1,6 +1,20 @@
-module Language.Mulang.Builder (compact, compactMap, compactConcatMap, normalize) where
+module Language.Mulang.Builder (
+    compact,
+    compactMap,
+    compactConcatMap,
+    normalize,
+    normalizeWith,
+    NormalizationOptions (..)) where
 
 import Language.Mulang.Ast
+
+data NormalizationOptions = NormalizationOptions {
+  convertObjectLevelFunctionIntoMethod :: Bool,
+  convertObjectLevelLambdaVariableIntoMethod :: Bool,
+  convertObjectLevelVariableIntoAttribute :: Bool,
+  sortTopLevelDeclarations :: Bool,
+  sortObjectLevelDeclarations :: Bool
+} deriving (Eq, Show)
 
 compactConcatMap :: (a -> [Expression]) -> [a] -> Expression
 compactConcatMap f = compact . concat . map f
@@ -13,41 +27,56 @@ compact []  = None
 compact [e] = e
 compact es  = Sequence es
 
+normalizeAllOptions :: NormalizationOptions
+normalizeAllOptions = NormalizationOptions {
+  convertObjectLevelFunctionIntoMethod = True,
+  convertObjectLevelLambdaVariableIntoMethod = True,
+  convertObjectLevelVariableIntoAttribute = True
+}
+
 normalize :: Expression -> Expression
-normalize (Variable n (MuObject e))        = Object n (normalizeInObject e)
-normalize (Variable n (Lambda vars e))     = SimpleFunction n vars (normalize e)
-normalize (Variable n e)                   = Variable n (normalize e)
-normalize (Function n equations)           = Function n (map normalizeEquation equations)
-normalize (Procedure n equations)          = Procedure n (map normalizeEquation equations)
-normalize (Fact n args)                    = Fact n args
-normalize (Rule n args es)                 = Rule n args (map normalize es)
-normalize (Method n equations)             = Method n (map normalizeEquation equations)
-normalize (Attribute n e)                  = Attribute n (normalize e)
-normalize (Object n e)                     = Object n (normalizeInObject e)
-normalize (Application (Send r m []) args) = Send (normalize r) (normalize m) (map normalize args)
-normalize (Application e es)               = Application (normalize e) (map normalize es)
-normalize (Send r e es)                    = Send (normalize r) (normalize e) (map normalize es)
-normalize (Lambda ps e2)                   = Lambda ps (normalize e2)
-normalize (If e1 e2 e3)                    = If (normalize e1) (normalize e2) (normalize e3)
-normalize (While e1 e2)                    = While (normalize e1) (normalize e2)
-normalize (Match e1 equations)             = Match (normalize e1) (map normalizeEquation equations)
-normalize (For stms e1)                    = For stms (normalize e1)
-normalize (ForLoop init cond prog stmt)    = ForLoop (normalize init) (normalize cond) (normalize prog) (normalize stmt)
-normalize (Return e)                       = Return (normalize e)
-normalize (Not e)                          = Not (normalize e)
-normalize (Forall e1 e2)                   = Forall (normalize e1) (normalize e2)
-normalize (Sequence es)                    = Sequence (map normalize es)
-normalize (MuObject e)                     = MuObject (normalize e)
-normalize (MuTuple es)                     = MuTuple (map normalize es)
-normalize (MuList es)                      = MuList (map normalize es)
-normalize e = e
+normalize = normalizeWith normalizeAllOptions
 
-normalizeInObject (Function n eqs)             = Method n (map normalizeEquation eqs)
-normalizeInObject (Variable n (Lambda vars e)) = SimpleMethod n vars (normalize e)
-normalizeInObject (Variable n e)               = Attribute n (normalize e)
-normalizeInObject (Sequence es)                = Sequence (map normalizeInObject es)
-normalizeInObject e                            = normalize e
+normalizeWith :: NormalizationOptions -> Expression -> Expression
+normalizeWith ops (Variable n (MuObject e))        = Object n (normalizeObjectLevelWith ops e)
+normalizeWith ops (Variable n (Lambda vars e))     = SimpleFunction n vars (normalizeWith ops e)
+normalizeWith ops (Variable n e)                   = Variable n (normalizeWith ops e)
+normalizeWith ops (Function n equations)           = Function n (mapNormalizeEquationWith ops equations)
+normalizeWith ops (Procedure n equations)          = Procedure n (mapNormalizeEquationWith ops equations)
+normalizeWith _   (Fact n args)                    = Fact n args
+normalizeWith ops (Rule n args es)                 = Rule n args (mapNormalizeWith ops es)
+normalizeWith ops (Method n equations)             = Method n (mapNormalizeEquationWith ops equations)
+normalizeWith ops (Attribute n e)                  = Attribute n (normalizeWith ops e)
+normalizeWith ops (Object n e)                     = Object n (normalizeObjectLevelWith ops e)
+normalizeWith ops (Application (Send r m []) args) = Send (normalizeWith ops r) (normalizeWith ops m) (mapNormalizeWith ops args)
+normalizeWith ops (Application e es)               = Application (normalizeWith ops e) (mapNormalizeWith ops es)
+normalizeWith ops (Send r e es)                    = Send (normalizeWith ops r) (normalizeWith ops e) (mapNormalizeWith ops es)
+normalizeWith ops (Lambda ps e2)                   = Lambda ps (normalizeWith ops e2)
+normalizeWith ops (If e1 e2 e3)                    = If (normalizeWith ops e1) (normalizeWith ops e2) (normalizeWith ops e3)
+normalizeWith ops (While e1 e2)                    = While (normalizeWith ops e1) (normalizeWith ops e2)
+normalizeWith ops (Match e1 equations)             = Match (normalizeWith ops e1) (mapNormalizeEquationWith ops equations)
+normalizeWith ops (For stms e1)                    = For stms (normalizeWith ops e1)
+normalizeWith ops (ForLoop init cond prog stmt)    = ForLoop (normalizeWith ops init) (normalizeWith ops cond) (normalizeWith ops prog) (normalizeWith ops stmt)
+normalizeWith ops (Return e)                       = Return (normalizeWith ops e)
+normalizeWith ops (Not e)                          = Not (normalizeWith ops e)
+normalizeWith ops (Forall e1 e2)                   = Forall (normalizeWith ops e1) (normalizeWith ops e2)
+normalizeWith ops (Sequence es)                    = Sequence (mapNormalizeWith ops es)
+normalizeWith ops (MuObject e)                     = MuObject (normalizeWith ops e)
+normalizeWith ops (MuTuple es)                     = MuTuple (mapNormalizeWith ops es)
+normalizeWith ops (MuList es)                      = MuList (mapNormalizeWith ops es)
+normalizeWith _ e = e
 
-normalizeEquation :: Equation -> Equation
-normalizeEquation (Equation ps (UnguardedBody e))   = Equation ps (UnguardedBody (normalize e))
-normalizeEquation (Equation ps (GuardedBody b))     = Equation ps (GuardedBody (map (\(c, e) -> (normalize c, normalize e)) b))
+mapNormalizeWith ops = map (normalizeWith ops)
+mapNormalizeEquationWith ops = map (normalizeEquationWith ops)
+
+
+normalizeObjectLevelWith :: NormalizationOptions -> Expression -> Expression
+normalizeObjectLevelWith ops (Function n eqs)             | convertObjectLevelFunctionIntoMethod ops       = Method n (mapNormalizeEquationWith ops eqs)
+normalizeObjectLevelWith ops (Variable n (Lambda vars e)) | convertObjectLevelLambdaVariableIntoMethod ops = SimpleMethod n vars (normalizeWith ops e)
+normalizeObjectLevelWith ops (Variable n e)               | convertObjectLevelVariableIntoAttribute ops    = Attribute n (normalizeWith ops e)
+normalizeObjectLevelWith ops (Sequence es)                = Sequence (map (normalizeObjectLevelWith ops) es)
+normalizeObjectLevelWith ops e                            = normalizeWith ops e
+
+normalizeEquationWith :: NormalizationOptions -> Equation -> Equation
+normalizeEquationWith ops (Equation ps (UnguardedBody e))   = Equation ps (UnguardedBody (normalizeWith ops e))
+normalizeEquationWith ops (Equation ps (GuardedBody b))     = Equation ps (GuardedBody (map (\(c, e) -> (normalizeWith ops c, normalizeWith ops e)) b))

--- a/src/Language/Mulang/Builder.hs
+++ b/src/Language/Mulang/Builder.hs
@@ -9,6 +9,8 @@ module Language.Mulang.Builder (
 import Language.Mulang.Ast
 
 data NormalizationOptions = NormalizationOptions {
+  convertTopLevelObjectVariableIntoObject :: Bool,
+  convertTopLevelLambdaVariableIntoFunction :: Bool,
   convertObjectLevelFunctionIntoMethod :: Bool,
   convertObjectLevelLambdaVariableIntoMethod :: Bool,
   convertObjectLevelVariableIntoAttribute :: Bool,
@@ -29,17 +31,21 @@ compact es  = Sequence es
 
 normalizeAllOptions :: NormalizationOptions
 normalizeAllOptions = NormalizationOptions {
+  convertTopLevelObjectVariableIntoObject = True,
+  convertTopLevelLambdaVariableIntoFunction = True,
   convertObjectLevelFunctionIntoMethod = True,
   convertObjectLevelLambdaVariableIntoMethod = True,
-  convertObjectLevelVariableIntoAttribute = True
+  convertObjectLevelVariableIntoAttribute = True,
+  sortTopLevelDeclarations = True,
+  sortObjectLevelDeclarations = True
 }
 
 normalize :: Expression -> Expression
 normalize = normalizeWith normalizeAllOptions
 
 normalizeWith :: NormalizationOptions -> Expression -> Expression
-normalizeWith ops (Variable n (MuObject e))        = Object n (normalizeObjectLevelWith ops e)
-normalizeWith ops (Variable n (Lambda vars e))     = SimpleFunction n vars (normalizeWith ops e)
+normalizeWith ops (Variable n (MuObject e))        | convertTopLevelObjectVariableIntoObject ops = Object n (normalizeObjectLevelWith ops e)
+normalizeWith ops (Variable n (Lambda vars e))     | convertTopLevelLambdaVariableIntoFunction ops = SimpleFunction n vars (normalizeWith ops e)
 normalizeWith ops (Variable n e)                   = Variable n (normalizeWith ops e)
 normalizeWith ops (Function n equations)           = Function n (mapNormalizeEquationWith ops equations)
 normalizeWith ops (Procedure n equations)          = Procedure n (mapNormalizeEquationWith ops equations)

--- a/src/Language/Mulang/Parsers/Haskell.hs
+++ b/src/Language/Mulang/Parsers/Haskell.hs
@@ -1,7 +1,7 @@
 module Language.Mulang.Parsers.Haskell (hs, parseHaskell) where
 
 import Language.Mulang.Ast
-import Language.Mulang.Builder
+import Language.Mulang.Builder (compact, normalizeWith, defaultNormalizationOptions, NormalizationOptions(..))
 import Language.Mulang.Parsers
 
 import Language.Haskell.Syntax
@@ -24,6 +24,7 @@ parseHaskell = orLeft . parseHaskell'
 
 parseHaskell' :: String -> ParseResult Expression
 parseHaskell' = fmap (normalize . mu) . parseModule . (++"\n")
+    where normalize = normalizeWith (defaultNormalizationOptions { sortAllSequenceDeclarations = True })
 
 mu :: HsModule -> Expression
 mu (HsModule _ _ _ _ decls) = compact (concatMap muDecls decls)

--- a/src/Language/Mulang/Parsers/Haskell.hs
+++ b/src/Language/Mulang/Parsers/Haskell.hs
@@ -1,7 +1,7 @@
 module Language.Mulang.Parsers.Haskell (hs, parseHaskell) where
 
 import Language.Mulang.Ast
-import Language.Mulang.Builder (compact, normalizeWith, defaultNormalizationOptions, NormalizationOptions(..))
+import Language.Mulang.Builder (compact, normalizeWith, defaultNormalizationOptions, NormalizationOptions(..), SequenceSortMode(..))
 import Language.Mulang.Parsers
 
 import Language.Haskell.Syntax
@@ -24,7 +24,7 @@ parseHaskell = orLeft . parseHaskell'
 
 parseHaskell' :: String -> ParseResult Expression
 parseHaskell' = fmap (normalize . mu) . parseModule . (++"\n")
-    where normalize = normalizeWith (defaultNormalizationOptions { sortAllSequenceDeclarations = True })
+    where normalize = normalizeWith (defaultNormalizationOptions { sortSequenceDeclarations = SortAll })
 
 mu :: HsModule -> Expression
 mu (HsModule _ _ _ _ decls) = compact (concatMap muDecls decls)

--- a/src/Language/Mulang/Parsers/Java.hs
+++ b/src/Language/Mulang/Parsers/Java.hs
@@ -6,7 +6,7 @@ module Language.Mulang.Parsers.Java (java, parseJava) where
 import Language.Mulang.Ast hiding (While, Return, Equal, Lambda, Try, Switch)
 import qualified Language.Mulang.Ast as M (Expression(While, Return, Equal, Lambda, Try, Switch))
 import Language.Mulang.Parsers
-import Language.Mulang.Builder (compact, compactMap, compactConcatMap)
+import Language.Mulang.Builder (compact, compactMap, compactConcatMap, normalize)
 
 import Language.Java.Parser
 import Language.Java.Syntax
@@ -25,7 +25,7 @@ java = orFail . parseJava'
 parseJava :: EitherParser
 parseJava = orLeft . parseJava'
 
-parseJava' = fmap m . j
+parseJava' = fmap (normalize . m) . j
 
 m (CompilationUnit _ _ typeDecls) = compactMap muTypeDecl $ typeDecls
 

--- a/src/Language/Mulang/Parsers/JavaScript.hs
+++ b/src/Language/Mulang/Parsers/JavaScript.hs
@@ -1,7 +1,7 @@
 module Language.Mulang.Parsers.JavaScript (js, parseJavaScript) where
 
 import Language.Mulang.Ast
-import Language.Mulang.Builder
+import Language.Mulang.Builder (compactMap, normalizeWith, defaultNormalizationOptions, NormalizationOptions(..), SequenceSortMode(..))
 import Language.Mulang.Parsers
 
 import Language.JavaScript.Parser.Parser (parse)
@@ -21,6 +21,7 @@ parseJavaScript = orNothing . parseJavaScript'
 
 parseJavaScript' :: String -> Either String Expression
 parseJavaScript' = fmap (normalize . muJSAST) . (`parse` "src")
+  where normalize = normalizeWith (defaultNormalizationOptions { sortSequenceDeclarations = SortUniqueNonVariables })
 
 muJSAST:: JSAST -> Expression
 muJSAST (JSAstProgram statements _)     = compactMap muJSStatement statements


### PR DESCRIPTION
:warning: Work In Progress

This PR allows mulang to

* generate the same ASTs if two solutions have the same contents but declarations are in different order
* expose the normalization API to the CLI, so that external generators can use it
* finer-grained customization of the normalization process

*Pending tasks*: 

* ~Add docs~ will be addressed in #184
* ~Add tests~
* ~Maybe we should ensure that reordering only occurs when there are no duplicated name declarations~