### PR TITLE
Improving ghcjslib build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2128,16 +2128,13 @@ See `gem/README` for more details.
 `mulang` can also be compiled to JavaScript library using [ghcjs](https://github.com/ghcjs/ghcjs) and [ghcjslib](https://github.com/flbulgarelli/ghcjslib), which allows you to use it from `node` or the browser.
 
 1. Run `ghcjslib/swap.sh` for swapping to GHCJS compiler
-2. Run `stack build` for building the ghcjs version. This will take a while depending on your computer
-3. Run `stack test` for running the tests
-4. Run `ghcjslib/build.sh` for building the `ghcjslib` release. It will be placed on `ghcjslib/build/mulang.js`
-5. Move to the project: `cd ghcjslib && nvm use`
-6. Test it: `npm test`
-7. Load it:
+2. Run `ghcjslib/build.sh` for building the `ghcjslib` release. It will be placed on `ghcjslib/build/mulang.js`
+3. Run `ghcjslib/tests.sh` for running both mocha and hspec tests.
+4. Load it:
    1. in the browser: `google-chrome ghcjslib/index.html`
-   2. in `node`: `node`, and then, within the interpreter, run: `let mulang = require('./build/mulang.js');`
-6. Try it: `mulang.analyse(...pass here a spec as described in the README....)`
-7. Run `cd .. && ghcjslib/swap.sh` again for swapping back to ghc
+   2. in `node`: run `node`, and then, within the interpreter, run: `let mulang = require('./ghcjslib/build/mulang.js');`
+5. Try it: `mulang.analyse(...pass here a spec as described in the README....)`
+6. Run `ghcjslib/swap.sh` again for swapping back to ghc
 
 # Tagging and releasing
 

--- a/README.md
+++ b/README.md
@@ -2127,9 +2127,15 @@ See `gem/README` for more details.
 
 `mulang` can also be compiled to JavaScript library using [ghcjs](https://github.com/ghcjs/ghcjs) and [ghcjslib](https://github.com/flbulgarelli/ghcjslib), which allows you to use it from `node` or the browser.
 
+> :warning: you will need `node >= 7` installed on your system. If you have `nvm`, before starting run the following:
+>
+> ```sh
+> $ nvm use $(cat ghcjslib/.nvmrc)
+>```
+
 1. Run `ghcjslib/swap.sh` for swapping to GHCJS compiler
 2. Run `ghcjslib/build.sh` for building the `ghcjslib` release. It will be placed on `ghcjslib/build/mulang.js`
-3. Run `ghcjslib/tests.sh` for running both mocha and hspec tests.
+3. Run `ghcjslib/test.sh` for running both mocha and hspec tests.
 4. Load it:
    1. in the browser: `google-chrome ghcjslib/index.html`
    2. in `node`: run `node`, and then, within the interpreter, run: `let mulang = require('./ghcjslib/build/mulang.js');`

--- a/ghcjslib/build.sh
+++ b/ghcjslib/build.sh
@@ -19,6 +19,7 @@ echo 'Building project...'
 stack build
 
 echo "Building $GHCJSLIB_BUNDLE..."
+mkdir -p $GHCJSLIB_BUILD_PATH
 
 echo ">> Cleaning $GHCJSLIB_BUNDLE"
 rm -f $GHCJSLIB_BUNDLE

--- a/ghcjslib/test.sh
+++ b/ghcjslib/test.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+pushd ghcjslib
+
+echo 'Running mocha tests...'
+npm test
+
+echo 'Generating hspec tests...'
+node -e '
+let fs = require("fs");
+let specs = fs.readdirSync("../spec")
+              .filter((it) => !it.startsWith("Spec"))
+              .map((it) => it.replace(".hs", ""));
+console.log(`Specs detected: ${specs.join(",")}`)
+
+let imports = specs.map((it) => `import qualified ${it}`).join("\n");
+let descriptions = specs.map((it) => `  describe "${it}" ${it}.spec`).join("\n");
+
+console.log("Writing Spec.hs");
+fs.writeFileSync("../spec/Spec.hs",`
+module Main where
+
+import Test.Hspec
+${imports}
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = do
+${descriptions}
+`);'
+
+popd
+echo 'Running hspec tests...'
+stack test
+
+echo 'Cleaning hspec tests...'
+echo spec/Spec.hs <<EOF
+module Main where
+
+import Test.Hspec
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = error "Don't run ghcjslib specs directly. Use ./ghcjslib/test.sh instead"
+EOF
+
+echo 'Done'
+

--- a/spec/Spec.hs.ghcjs
+++ b/spec/Spec.hs.ghcjs
@@ -1,57 +1,9 @@
 module Main where
 
 import Test.Hspec
-import qualified AnalysisJsonSpec
-import qualified CombinerSpec
-import qualified DomainLanguageSpec
-import qualified DuplicationSpec
-import qualified ExpectationsAnalyzerSpec
-import qualified ExpectationsCompilerSpec
-import qualified ExplorerSpec
-import qualified FunctionalInspectorSpec
-import qualified HaskellSpec
-import qualified InspectorSpec
-import qualified JavaScriptSpec
-import qualified JavaSpec
-import qualified LogicSpec
-import qualified PolymorphismSpec
-import qualified PrologSpec
-import qualified PythonSpec
-import qualified SampleParserSpec
-import qualified SignaturesAnalyzerSpec
-import qualified SignatureSpec
-import qualified SmellsAnalyzerSpec
-import qualified SmellSpec
-import qualified TokenizerSpec
-import qualified TypedInspectorSpec
-import qualified UnfoldSpec
 
 main :: IO ()
 main = hspec spec
 
 spec :: Spec
-spec = do
-  describe "AnalysisJsonSpec" AnalysisJsonSpec.spec
-  describe "CombinerSpec" CombinerSpec.spec
-  describe "DomainLanguageSpec" DomainLanguageSpec.spec
-  describe "DuplicationSpec" DuplicationSpec.spec
-  describe "ExpectationsAnalyzerSpec" ExpectationsAnalyzerSpec.spec
-  describe "ExpectationsCompilerSpec" ExpectationsCompilerSpec.spec
-  describe "ExplorerSpec" ExplorerSpec.spec
-  describe "FunctionalInspectorSpec" FunctionalInspectorSpec.spec
-  describe "HaskellSpec" HaskellSpec.spec
-  describe "InspectorSpec" InspectorSpec.spec
-  describe "JavaScriptSpec" JavaScriptSpec.spec
-  describe "JavaSpec" JavaSpec.spec
-  describe "LogicSpec" LogicSpec.spec
-  describe "PolymorphismSpec" PolymorphismSpec.spec
-  describe "PrologSpec" PrologSpec.spec
-  describe "PythonSpec" PythonSpec.spec
-  describe "SampleParserSpec" SampleParserSpec.spec
-  describe "SignaturesAnalyzerSpec" SignaturesAnalyzerSpec.spec
-  describe "SignatureSpec" SignatureSpec.spec
-  describe "SmellsAnalyzerSpec" SmellsAnalyzerSpec.spec
-  describe "SmellSpec" SmellSpec.spec
-  describe "TokenizerSpec" TokenizerSpec.spec
-  describe "TypedInspectorSpec" TypedInspectorSpec.spec
-  describe "UnfoldSpec" UnfoldSpec.spec
+spec = error "Don't run ghcjslib specs directly. Use ./ghcjslib/test.sh instead"


### PR DESCRIPTION
Generating `Spec.hs` automatically in ghcjslib build, and simplifying build instructions