### PR TITLE
Miscellaneous fixes to java, javascript and python parsers  

### DIFF
--- a/spec/JavaScriptSpec.hs
+++ b/spec/JavaScriptSpec.hs
@@ -54,7 +54,7 @@ spec = do
                 SimpleProcedure
                     "f"
                     [VariablePattern "x"]
-                    (Send (Reference "console") (Reference "log") [MuString "fruit"]))
+                    (Print (MuString "fruit")))
 
     it "multiple params function declaration" $ do
       js "function f(x, y) { return 1 }" `shouldBe` hs "f x y = 1"

--- a/spec/JavaSpec.hs
+++ b/spec/JavaSpec.hs
@@ -52,6 +52,12 @@ spec = do
     it "parses Interface with superinterfaces" $ do
       run "public interface Foo extends Bar, Baz {}" `shouldBe` Interface "Foo" ["Bar", "Baz"] None
 
+    it "parses Class With initializers" $ do
+      run [text|
+            class Foo {
+               static { System.out.println("hello"); }
+            }|] `shouldBe` Class "Foo" Nothing (Print (MuString "hello"))
+
     it "parses Class With Methods" $ do
       run [text|
             class Foo {

--- a/spec/PythonSpec.hs
+++ b/spec/PythonSpec.hs
@@ -22,6 +22,11 @@ spec = do
 
     it "parses booleans" $ do
       py "True" `shouldBe` MuBool True
+      py "False" `shouldBe` MuBool False
+
+    it "parses booleans in version2" $ do
+      py2 "True" `shouldBe` MuBool True
+      py2 "False" `shouldBe` MuBool False
 
     it "parses strings" $ do
       py "\"some string\"" `shouldBe` MuString "some string"

--- a/spec/PythonSpec.hs
+++ b/spec/PythonSpec.hs
@@ -24,11 +24,14 @@ spec = do
       py "True" `shouldBe` MuBool True
 
     it "parses strings" $ do
-      py "\"some string\"" `shouldBe` MuString "\"some string\""
+      py "\"some string\"" `shouldBe` MuString "some string"
+
+    it "parses strings sequences" $ do
+      py "\"hello\" \"world\"" `shouldBe` MuString "helloworld"
 
     it "parses multi-line strings" $ do
       run [text|"""some
-      string"""|] `shouldBe` MuString "\"\"\"some\nstring\"\"\""
+      string"""|] `shouldBe` MuString "some\nstring"
 
     it "parses lists" $ do
       py "[1,2,3]" `shouldBe` MuList [MuNumber 1, MuNumber 2, MuNumber 3]
@@ -104,7 +107,7 @@ except:
       py "raise" `shouldBe` Raise None
 
     it "parses raise expressions with exception" $ do
-      py "raise Exception('something')" `shouldBe` Raise (Application (Reference "Exception") [MuString "'something'"])
+      py "raise Exception('something')" `shouldBe` Raise (Application (Reference "Exception") [MuString "something"])
 
     it "parses raise expressions with exception in version2 format" $ do
       py2 "raise Exception('something')" `shouldBe` Raise (Application (Reference "Exception") [MuString "'something'"])
@@ -120,7 +123,7 @@ except:
       py "lambda x: 1" `shouldBe` Lambda [VariablePattern "x"] (MuNumber 1)
 
     it "parses tuples" $ do
-      py "(1, \"something\")" `shouldBe` MuTuple [MuNumber 1, MuString "\"something\""]
+      py "(1, \"something\")" `shouldBe` MuTuple [MuNumber 1, MuString "something"]
 
     it "parses yields" $ do
       py "yield 1" `shouldBe` Yield (MuNumber 1)

--- a/spec/PythonSpec.hs
+++ b/spec/PythonSpec.hs
@@ -81,7 +81,7 @@ spec = do
       py "def foo(): return 1" `shouldBe` SimpleFunction "foo" [] (Return (MuNumber 1.0))
 
     it "parses procedures" $ do
-      py "def foo(param): print(param)" `shouldBe` SimpleProcedure "foo" [VariablePattern "param"] (Application (Reference "print") [Reference "param"])
+      py "def foo(param): print(param)" `shouldBe` SimpleProcedure "foo" [VariablePattern "param"] (Print (Reference "param"))
 
     it "parses whiles" $ do
       py "while True: pass" `shouldBe` While (MuBool True) None
@@ -110,12 +110,12 @@ except:
       py "raise Exception('something')" `shouldBe` Raise (Application (Reference "Exception") [MuString "something"])
 
     it "parses raise expressions with exception in version2 format" $ do
-      py2 "raise Exception('something')" `shouldBe` Raise (Application (Reference "Exception") [MuString "'something'"])
-      py2 "raise Exception, 'something'" `shouldBe` Raise (Application (Reference "Exception") [MuString "'something'"])
+      py2 "raise Exception('something')" `shouldBe` Raise (Application (Reference "Exception") [MuString "something"])
+      py2 "raise Exception, 'something'" `shouldBe` Raise (Application (Reference "Exception") [MuString "something"])
       py2 "raise Exception" `shouldBe` Raise (Reference "Exception")
 
     it "parses raise expressions with exception in version3 format" $ do
-      py3 "raise Exception('something')" `shouldBe` Raise (Application (Reference "Exception") [MuString "'something'"])
+      py3 "raise Exception('something')" `shouldBe` Raise (Application (Reference "Exception") [MuString "something"])
       evaluate (py3 "raise Exception, 'something'") `shouldThrow` anyErrorCall
       py3 "raise Exception" `shouldBe` Raise (Reference "Exception")
 

--- a/spec/SmellSpec.hs
+++ b/spec/SmellSpec.hs
@@ -7,6 +7,7 @@ import           Language.Mulang.Ast
 import           Language.Mulang.Inspector.Generic.Smell
 import           Language.Mulang.Parsers.Haskell (hs)
 import           Language.Mulang.Parsers.JavaScript (js)
+import           Language.Mulang.Parsers.Python (py)
 import           Language.Mulang.Parsers.Java (java)
 import           Language.Mulang.Parsers.Prolog (pl)
 
@@ -200,12 +201,27 @@ spec = do
     it "is False when there is no catch" $ do
       discardsExceptions (javaStatement "new Bar().baz();")  `shouldBe` False
 
-  describe "doesConsolePrint" $ do
-    it "is True java's system.out is used" $ do
+  describe "doesConsolePrint, in java" $ do
+    it "is True when java's system.out is used" $ do
       doesConsolePrint (javaStatement "int i = 4; System.out.println(4);") `shouldBe` True
 
     it "is False when no print is used" $ do
       doesConsolePrint (javaStatement "int i = 4; System.err.println(4);") `shouldBe` False
+
+  describe "doesConsolePrint, in javascript" $ do
+    it "is True when console.log is used" $ do
+      doesConsolePrint (js "console.log(4);") `shouldBe` True
+
+    it "is False when no print is used" $ do
+      doesConsolePrint (js "mylog.log(4);") `shouldBe` False
+
+  describe "doesConsolePrint, in python" $ do
+    it "is True when print is used" $ do
+      doesConsolePrint (py "print(4);") `shouldBe` True
+
+    it "is False when no print is used" $ do
+      doesConsolePrint (py "prune(4);") `shouldBe` False
+
 
   describe "hasLongParameterList" $ do
     it "is True when a function has over 4 parameters" $ do
@@ -263,7 +279,7 @@ spec = do
     it "is False when no equation follows " $ do
       hasUnreachableCode (runHaskell [text|
         foo _ = 1
-        |]) `shouldBe` False      
+        |]) `shouldBe` False
 
     it "is False when not all patterns match any value" $ do
       hasUnreachableCode (runHaskell [text|

--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -1,6 +1,7 @@
 module Data.List.Extra (
   headOrElse,
-  has) where
+  has,
+  dropLast) where
 
 headOrElse :: a -> [a] -> a
 headOrElse x []     = x
@@ -8,3 +9,6 @@ headOrElse _ (x:_)  = x
 
 has :: (a -> Bool) -> (b -> [a]) -> (b -> Bool)
 has f g = any f . g
+
+dropLast :: Int -> String -> String
+dropLast n xs = take (length xs - n) xs

--- a/src/Language/Mulang/Parsers/Java.hs
+++ b/src/Language/Mulang/Parsers/Java.hs
@@ -16,7 +16,7 @@ import Control.Fallible
 
 import Data.Maybe (fromMaybe)
 import Data.List (intercalate, partition)
-import Data.List.Extra (headOrElse)
+import Data.List.Extra (headOrElse, dropLast)
 import Data.Char (toLower)
 
 java :: Parser
@@ -213,7 +213,3 @@ r (ClassType [(name, _)]) = i name
 j = parser compilationUnit
 
 ns = intercalate "." . map i
-
--- list helpers
-
-dropLast n xs = take (length xs - n) xs

--- a/src/Language/Mulang/Parsers/Java.hs
+++ b/src/Language/Mulang/Parsers/Java.hs
@@ -52,7 +52,7 @@ muDeclaration name args decl = Sequence [ModuleSignature (i name) (map prettyPri
 
 muDecl :: Decl -> [Expression]
 muDecl (MemberDecl memberDecl) = muMemberDecl memberDecl
-muDecl e                       = return . debug $ e
+muDecl (InitDecl _ block)      = [muBlock block]
 
 muMemberDecl :: MemberDecl -> [Expression]
 muMemberDecl (FieldDecl _ typ varDecls)                              = concatMap (variableToAttribute.muVarDecl typ) varDecls

--- a/src/Language/Mulang/Parsers/JavaScript.hs
+++ b/src/Language/Mulang/Parsers/JavaScript.hs
@@ -57,6 +57,7 @@ muJSStatement (JSLet _ list _)                                              = mu
 muJSStatement (JSWhile _ _ expression _ statement)                          = While (muJSExpression expression) (muJSStatement statement)
 muJSStatement e                                                             = debug e
 
+normalizeReference (SimpleSend  (Reference "console") "log"      [value])                    = Print value
 normalizeReference (SimpleSend  (Reference "assert") "equals"    [expected, actual])         = Assert False $ Equality expected actual
 normalizeReference (SimpleSend  (Reference "assert") "notEquals" [expected, actual])         = Assert True $ Equality expected actual
 normalizeReference (SimpleSend  (Reference "assert") "throws"    [block, error])             = Assert False $ Failure block error

--- a/src/Language/Mulang/Parsers/Python.hs
+++ b/src/Language/Mulang/Parsers/Python.hs
@@ -125,6 +125,8 @@ muSuite = compactMap muStatement
 
 
 muExpr :: ExprSpan -> M.Expression
+muExpr (Var (Ident "True" _) _)   = M.MuTrue
+muExpr (Var (Ident "False" _) _)  = M.MuFalse
 muExpr (Var ident _)              = M.Reference (muIdent ident)
 muExpr (Int value _ _)            = muNumberFromInt value
 muExpr (LongInt value _ _)        = muNumberFromInt value

--- a/src/Language/Mulang/Parsers/Python.hs
+++ b/src/Language/Mulang/Parsers/Python.hs
@@ -15,7 +15,8 @@ import qualified Language.Python.Version2.Parser as Python2
 import           Language.Python.Common.Token (Token)
 import           Language.Python.Common.AST
 
-import           Data.List (intercalate, isPrefixOf)
+import           Data.List (isPrefixOf)
+import           Data.List.Extra (dropLast)
 import           Data.Maybe (fromMaybe, listToMaybe)
 
 import           Control.Fallible
@@ -176,7 +177,12 @@ muCall callType ident = callType (M.Reference $ muIdent ident)
 
 muApplication op args = M.Application (muOp op) (map muExpr args)
 
-muString = M.MuString . intercalate "\n"
+muString = M.MuString . concat . map removeQuotes
+  where removeQuotes ('"':'"':'"':rest)    = dropLast 3 rest
+        removeQuotes ('"':rest)            = dropLast 1 rest
+        removeQuotes ('\'':'\'':'\'':rest) = dropLast 3 rest
+        removeQuotes ('\'':rest)           = dropLast 1 rest
+        removeQuotes other                 = other
 
 muNumberFromInt = M.MuNumber . fromInteger
 

--- a/src/Language/Mulang/Parsers/Python.hs
+++ b/src/Language/Mulang/Parsers/Python.hs
@@ -170,6 +170,7 @@ muCallType (Dot _ (Ident "assertEqual" _) _) [a, b] = M.Assert False $ M.Equalit
 muCallType (Dot _ (Ident "assertTrue" _) _)  [a]    = M.Assert False $ M.Truth a
 muCallType (Dot _ (Ident "assertFalse" _) _) [a]    = M.Assert True $ M.Truth a
 muCallType (Dot receiver ident _)            x      = muCall (M.Send $ muExpr receiver) ident x
+muCallType (Var (Ident "print" _) _)         [x]    = M.Print x -- FIXME python print can have multiple arguments
 muCallType (Var ident _)                     x      = muCall M.Application ident x
 
 muCall callType ident = callType (M.Reference $ muIdent ident)


### PR DESCRIPTION
Some commits were extracted from #232 

Fixes: 

* removing odd quotes in python strings
* properly parsing python's `print`
* properly parsing javascript's `console.log`
* parsing Java initializers
* supporting booleans in python 2  