### PR TITLE
Introducing locate and top-level smells

### DIFF
--- a/spec/CombinerSpec.hs
+++ b/spec/CombinerSpec.hs
@@ -2,16 +2,34 @@ module CombinerSpec (spec) where
 
 import           Test.Hspec
 import           Language.Mulang
+import           Language.Mulang.Inspector.Generic.Smell
 import           Language.Mulang.Parsers.Haskell
+import           Language.Mulang.Parsers.JavaScript
 
 spec :: Spec
 spec = do
   describe "detect" $ do
     it "can detect inspections" $ do
       let code = hs "x = if True then True else False\n\
-                 \y = 2\n\
-                 \z = if True then True else False"
+                    \y = 2\n\
+                    \z = if True then True else False"
       detect usesIf code `shouldBe` ["x", "z"]
+
+    it "can detect inspections at top level" $ do
+      detect doesConsolePrint (js "console.log(hello)") `shouldBe` []
+
+  describe "locate" $ do
+    it "can locate nested inspections" $ do
+      let code = hs "x = if True then True else False\n\
+                    \y = 2\n\
+                    \z = if True then True else False"
+      locate usesIf code `shouldBe` Nested ["x", "z"]
+
+    it "can locate inspections at top level" $ do
+      locate doesConsolePrint (js "console.log(hello)") `shouldBe` TopLevel
+
+    it "fails when inspection is not present" $ do
+      locate usesWhile (js "hello") `shouldBe` Nowhere
 
   describe "negate" $ do
     it "is False when inspection is true" $ do

--- a/spec/SmellsAnalyzerSpec.hs
+++ b/spec/SmellsAnalyzerSpec.hs
@@ -27,7 +27,10 @@ spec = describe "SmellsAnalyzer" $ do
                                                     Expectation "fooBar" "HasWrongCaseIdentifiers"])
 
   describe "Using exclusion" $ do
-    it "works with empty set" $ do
+    it "works with empty set, in java" $ do
+      (runExcept Java "class Foo { static { System.out.println(\"foo\"); } }" []) `shouldReturn` (result [Expectation "Foo" "DoesConsolePrint"])
+
+    it "works with empty set, in haskell" $ do
       (runExcept Haskell "fun x = if x then True else False" []) `shouldReturn` (result [Expectation "fun" "HasRedundantIf"])
 
     describe "detect domain language violations" $ do
@@ -53,10 +56,17 @@ spec = describe "SmellsAnalyzer" $ do
                   "function foo() { return 1; }"
                   ["HasRedundantLocalVariableReturn"]) `shouldReturn` (result [])
 
-  describe "Using inclusion" $ do
-    it "works with empty set" $ do
-      (runOnly Haskell "f x = if x then True else False" []) `shouldReturn` (result [])
+    describe "works with top level detections" $ do
+      it "works with empty set, in Python" $ do
+        (runExcept Python "print(4)" []) `shouldReturn` (result [Expectation "*" "DoesConsolePrint"])
+
+      it "works with empty set, in JavaScript" $ do
+        (runExcept JavaScript "console.log(4)" []) `shouldReturn` (result [Expectation "*" "DoesConsolePrint"])
+
 
   describe "Using inclusion" $ do
-    it "works with empty set" $ do
+    it "works with empty set, in haskell" $ do
+      (runOnly Haskell "f x = if x then True else False" []) `shouldReturn` (result [])
+
+    it "works with empty set, in python" $ do
       (runExcept Python "def funcion():\n  if True:\n    pass\n  else:\n    return 1" []) `shouldReturn` (result [Expectation "funcion" "HasEmptyIfBranches"])

--- a/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
+++ b/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
@@ -5,7 +5,7 @@ import Language.Mulang
 import Language.Mulang.Inspector.Generic.Smell
 import Language.Mulang.DomainLanguage
 import Language.Mulang.Analyzer.Analysis hiding (DomainLanguage)
-import Data.List
+import Data.List ((\\))
 import Data.Maybe (fromMaybe)
 
 analyseSmells :: Expression -> DomainLanguage -> Maybe SmellsSet -> [Expectation]
@@ -86,10 +86,15 @@ unsupported :: Detection
 unsupported _ _ = []
 
 simple :: Inspection -> Detection
-simple inspection _ = detect inspection
+simple inspection _ = locate' inspection
 
 withLanguage :: (DomainLanguage -> Inspection) -> Detection
-withLanguage inspection language = detect (inspection language)
+withLanguage inspection language = locate' (inspection language)
 
 exectationFor :: Smell -> Identifier -> Expectation
 exectationFor smell identifier = Expectation identifier smell
+
+locate' inspection = identifiers . locate inspection
+  where identifiers Nowhere      = []
+        identifiers TopLevel     = ["*"]
+        identifiers (Nested ids) = ids

--- a/src/Language/Mulang/Inspector/Combiner.hs
+++ b/src/Language/Mulang/Inspector/Combiner.hs
@@ -16,17 +16,19 @@ import Language.Mulang.Inspector.Primitive
 
 type Modifier = Inspection -> Inspection
 
+data Location
+  = Nowhere                   -- ^ No subexpression match, nor the whole expression
+  | TopLevel                  -- ^ No subexpression match, but the whole expression
+  | Nested [Identifier]       -- ^ One ore more subexpressions match
+  deriving (Show, Eq)
+
+-- | Answers those identifiers that are bound to expressions that match the given inspection
 detect :: Inspection -> Expression -> [Identifier]
 detect i expression =
   filter (`inspection` expression) $ declaredIdentifiers expression
     where inspection = scoped' i
 
-data Location
-  = Nowhere
-  | TopLevel
-  | Nested [Identifier]
-  deriving (Show, Eq)
-
+-- | Answers the Locations of those expressions that match the given inspection
 locate :: Inspection -> Expression -> Location
 locate inspection expression
   | identifiers@(_:_) <- detect inspection expression = Nested identifiers

--- a/src/Language/Mulang/Inspector/Combiner.hs
+++ b/src/Language/Mulang/Inspector/Combiner.hs
@@ -1,11 +1,13 @@
 module Language.Mulang.Inspector.Combiner (
   detect,
+  locate,
   negative,
   alternative,
   scoped,
   scopedList,
   transitive,
   transitiveList,
+  Location (..),
   Modifier) where
 
 import Language.Mulang.Ast
@@ -18,6 +20,18 @@ detect :: Inspection -> Expression -> [Identifier]
 detect i expression =
   filter (`inspection` expression) $ declaredIdentifiers expression
     where inspection = scoped' i
+
+data Location
+  = Nowhere
+  | TopLevel
+  | Nested [Identifier]
+  deriving (Show, Eq)
+
+locate :: Inspection -> Expression -> Location
+locate inspection expression
+  | identifiers@(_:_) <- detect inspection expression = Nested identifiers
+  | inspection expression = TopLevel
+  | otherwise = Nowhere
 
 alternative :: Inspection -> Modifier
 alternative i1 i2 expression = i1 expression || i2 expression


### PR DESCRIPTION
Depends on #235 

Currently, smells can only be detected if they occur within a declaration. This PR adds support for detecting smells at top-level, too. 