### PR TITLE
Refactor assignments exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,22 +519,25 @@ You can also use Mulang from the Command Line, without having to interact with H
 
 In order to pass expectations to the Command Line Tool, you must use a simple DSL that builds the inspections for you.
 
-| Kind              | DSL Sample                   | Haskell Combinators Sample
-|-------------------|------------------------------|----------------------------
-| Basic             | `* UsesIf`                   | `usesIf`
-| Negated           | `* Not:UsesWhile`            | `(negative usesWhile)`
-| Predicated        | `* DeclaresClass:Foo`        | `(declaresClass (named "Foo"))`
-|                   | `* DeclaresClass:=Foo`       | `(declaresClass (named "Foo"))`
-|                   | `* DeclaresClass:~Foo`       | `(declaresClass (like "Foo"))`
-|                   | `* DeclaresClass:^Foo`       | `(declaresClass (except "Foo"))`
-|                   | `* DeclaresClass:[Foo\|Bar]` | `(declaresClass (anyOf ["Foo", "Bar"]))`
-|                   | `* DeclaresClass:*`          | `(declaresClass anyone)`
-|                   | `* DeclaresClass`            | `(declaresClass anyone)`
-| Matching Literals | `* Calls:*:With:1:True`      | `(callsMatching (withEvery ["1", "True"]) anyone)`
-|                   | `* Returns:With:1`           | `(returnsMatching (with "1") anyone)`
-| Transitive        | `foo UsesLambda`             | `(transitive usesLambda "foo")`
-| Scoped            | `Intransitive:foo UsesIf`    | `(scoped usesIf "foo")`
-| Scoped List       | `foo.bar UsesIf`             | `(scopedList usesIf ["foo", "bar"])`
+| Kind              | DSL Sample                         | Haskell Combinators Sample
+|-------------------|------------------------------------|----------------------------
+| Basic             | `* UsesIf`                         | `usesIf`
+| Negated           | `* Not:UsesWhile`                  | `(negative usesWhile)`
+| Predicated        | `* DeclaresClass:Foo`              | `(declaresClass (named "Foo"))`
+|                   | `* DeclaresClass:=Foo`             | `(declaresClass (named "Foo"))`
+|                   | `* DeclaresClass:~Foo`             | `(declaresClass (like "Foo"))`
+|                   | `* DeclaresClass:^Foo`             | `(declaresClass (except "Foo"))`
+|                   | `* DeclaresClass:[Foo\|Bar]`       | `(declaresClass (anyOf ["Foo", "Bar"]))`
+|                   | `* DeclaresClass:*`                | `(declaresClass anyone)`
+|                   | `* DeclaresClass`                  | `(declaresClass anyone)`
+| Matching Literals | `* Calls:*:WithChar:'a':WithTrue`  | `(callsMatching (withEvery [isChar 'a', isBool True]) anyone)`
+|                   | `* Calls:*:WithNil`                | `(callsMatching (withEvery [isNil]) anyone)`
+|                   | `* Returns:WithNumber:1`           | `(returnsMatching (withEvery [isNumber 1]) anyone)`
+|                   | `* Returns:WithString:"foo"`       | `(returnsMatching (withEvery [isString "foo"]) anyone)`
+|                   | `* Returns:WithSymbol:"foo"`       | `(returnsMatching (withEvery [isSymbol "foo"]) anyone)`
+| Transitive        | `foo UsesLambda`                   | `(transitive usesLambda "foo")`
+| Scoped            | `Intransitive:foo UsesIf`          | `(scoped usesIf "foo")`
+| Scoped List       | `foo.bar UsesIf`                   | `(scopedList usesIf ["foo", "bar"])`
 
 
 ## Examples

--- a/spec/ExpectationsCompilerSpec.hs
+++ b/spec/ExpectationsCompilerSpec.hs
@@ -154,7 +154,9 @@ spec = do
 
   it "works with Calls WithNumber and WithTrue" $ do
     run (hs "f a b = g 1 True") "f" "Calls:g:WithNumber:1:WithTrue" `shouldBe` True
+    run (hs "f a b = g 1 False") "f" "Calls:g:WithNumber:1:WithFalse" `shouldBe` True
     run (hs "f a b = g 2") "f" "Calls:g:WithNumber:1:WithTrue" `shouldBe` False
+    run (hs "f a b = g True") "f" "Calls:g:WithNumber:1:WithFalse" `shouldBe` False
 
   it "works with Assigns WithNumber" $ do
     run (java "class Foo { int x = 4; }") "Foo" "Assigns:x:WithNumber:4" `shouldBe` True

--- a/spec/ExpectationsCompilerSpec.hs
+++ b/spec/ExpectationsCompilerSpec.hs
@@ -3,6 +3,7 @@ module ExpectationsCompilerSpec (spec) where
 import           Test.Hspec
 import           Language.Mulang.Analyzer hiding (spec)
 import           Language.Mulang.Analyzer.ExpectationsCompiler (compileExpectation)
+import           Language.Mulang.Ast
 import           Language.Mulang.Parsers.Haskell
 import           Language.Mulang.Parsers.JavaScript
 import           Language.Mulang.Parsers.Java
@@ -147,25 +148,40 @@ spec = do
     run (hs "f a b = g") "f" "Calls:g" `shouldBe` False
     run (hs "f a b = g b") "f" "Calls:g" `shouldBe` True
 
-  it "works with Calls With" $ do
-    run (hs "f a b = g 1") "f" "Calls:g:With:1" `shouldBe` True
-    run (hs "f a b = g 2") "f" "Calls:g:With:1" `shouldBe` False
+  it "works with Calls WithNumber" $ do
+    run (hs "f a b = g 1") "f" "Calls:g:WithNumber:1" `shouldBe` True
+    run (hs "f a b = g 2") "f" "Calls:g:WithNumber:1" `shouldBe` False
 
-    run (hs "f a b = g 1 True") "f" "Calls:g:With:1:True" `shouldBe` True
-    run (hs "f a b = g 2") "f" "Calls:g:With:1:True" `shouldBe` False
+  it "works with Calls WithNumber and WithTrue" $ do
+    run (hs "f a b = g 1 True") "f" "Calls:g:WithNumber:1:WithTrue" `shouldBe` True
+    run (hs "f a b = g 2") "f" "Calls:g:WithNumber:1:WithTrue" `shouldBe` False
 
-  it "works with Assigns With" $ do
-    run (java "class Foo { int x = 4; }") "Foo" "Assigns:x:With:4" `shouldBe` True
-    run (java "class Foo { char x = 'a'; }") "Foo" "Assigns:x:With:'a'" `shouldBe` True
-    run (java "class Foo { char x = 'b'; }") "Foo" "Assigns:x:With:'a'" `shouldBe` False
+  it "works with Assigns WithNumber" $ do
+    run (java "class Foo { int x = 4; }") "Foo" "Assigns:x:WithNumber:4" `shouldBe` True
+    run (java "class Foo { int x = 4; }") "Foo" "Assigns:x:WithNumber:5" `shouldBe` False
 
-    run (java "class Foo { char x = 'b'; }") "Foo" "Assigns:*:With:'b'" `shouldBe` True
-    run (java "class Foo { char x = 'b'; }") "Foo" "Assigns:*:With:'c'" `shouldBe` False
+  it "works with Assigns WithSymbol" $ do
+    run (Assignment "x" (MuSymbol "foo")) "*" "Assigns:x:WithSymbol:\"foo\"" `shouldBe` True
+    run (Assignment "x" (MuSymbol "foo")) "*" "Assigns:x:WithSymbol:\"bar\"" `shouldBe` False
 
-  it "works with Returns With" $ do
-    run (java "class Foo { int foo() { return -1; } }") "Foo" "Returns:With:-1" `shouldBe` True
-    run (java "class Foo { int foo() { return -1; } }") "Foo" "Returns:With:0" `shouldBe` False
-    run (java "class Foo { int foo() { int x = -1; } }") "Foo" "Returns:With:-1" `shouldBe` False
+  it "works with Assigns WithChar" $ do
+    run (java "class Foo { char x = 'a'; }") "Foo" "Assigns:x:WithChar:'a'" `shouldBe` True
+    run (java "class Foo { char x = 'b'; }") "Foo" "Assigns:x:WithChar:'a'" `shouldBe` False
+
+    run (java "class Foo { char x = 'b'; }") "Foo" "Assigns:*:WithChar:'b'" `shouldBe` True
+    run (java "class Foo { char x = 'b'; }") "Foo" "Assigns:*:WithChar:'c'" `shouldBe` False
+
+  it "works with Assigns WithString" $ do
+    run (java "class Foo { char x = \"hello\"; }") "Foo" "Assigns:x:WithString:\"hello\"" `shouldBe` True
+    run (java "class Foo { char x = \"world\"; }") "Foo" "Assigns:x:WithString:\"hello\"" `shouldBe` False
+
+    run (java "class Foo { char x = \"world\"; }") "Foo" "Assigns:*:WithString:\"world\"" `shouldBe` True
+    run (java "class Foo { char x = \"world\"; }") "Foo" "Assigns:*:WithString:\"hello\"" `shouldBe` False
+
+  it "works with Returns WithNumber" $ do
+    run (java "class Foo { int foo() { return 9; } }") "Foo" "Returns:WithNumber:9" `shouldBe` True
+    run (java "class Foo { int foo() { int x = 4; } }") "Foo" "Returns:WithNumber:4" `shouldBe` False
+    run (java "class Foo { int foo() { return 3; } }") "Foo" "Returns:WithNumber:0" `shouldBe` False
 
   it "works with UsesInheritance" $ do
     run (java "class Foo extends Bar {}") "Foo" "UsesInheritance" `shouldBe` True

--- a/spec/ExpectationsCompilerSpec.hs
+++ b/spec/ExpectationsCompilerSpec.hs
@@ -161,8 +161,8 @@ spec = do
     run (java "class Foo { int x = 4; }") "Foo" "Assigns:x:WithNumber:5" `shouldBe` False
 
   it "works with Assigns WithSymbol" $ do
-    run (Assignment "x" (MuSymbol "foo")) "*" "Assigns:x:WithSymbol:\"foo\"" `shouldBe` True
-    run (Assignment "x" (MuSymbol "foo")) "*" "Assigns:x:WithSymbol:\"bar\"" `shouldBe` False
+    run (Assignment "x" (MuSymbol "foo")) "*" "Assigns:x:WithSymbol:foo" `shouldBe` True
+    run (Assignment "x" (MuSymbol "foo")) "*" "Assigns:x:WithSymbol:bar" `shouldBe` False
 
   it "works with Assigns WithChar" $ do
     run (java "class Foo { char x = 'a'; }") "Foo" "Assigns:x:WithChar:'a'" `shouldBe` True

--- a/spec/InspectorSpec.hs
+++ b/spec/InspectorSpec.hs
@@ -411,10 +411,10 @@ spec = do
       calls (named "m") (EntryPoint "main" (Reference "f")) `shouldBe` False
 
     it "is True when using a matcher that matches" $ do
-      (callsMatching (with "1") anyone) (hs "f = g 1") `shouldBe` True
+      (callsMatching (with . isNumber $ 1) anyone) (hs "f = g 1") `shouldBe` True
 
     it "is False when using a matcher that does not match" $ do
-      (callsMatching (with "1") anyone) (hs "f = g 2") `shouldBe` False
+      (callsMatching (with . isNumber $ 1) anyone) (hs "f = g 2") `shouldBe` False
 
   describe "usesExceptions" $ do
     it "is True when a raise is used, java" $ do

--- a/spec/LiteralSpec.hs
+++ b/spec/LiteralSpec.hs
@@ -5,38 +5,32 @@ import           Language.Mulang
 
 spec :: Spec
 spec = do
-  describe "isLiteral" $ do
+  describe "literal inspections" $ do
     it "works with numbers" $ do
 
-      isLiteral "4" (MuNumber 4) `shouldBe` True
-      isLiteral "4" (MuNumber 4.0) `shouldBe` True
-      isLiteral "4.5" (MuNumber 4.5) `shouldBe` True
-
-      isLiteral "4" (MuNumber 5.0) `shouldBe` False
-      isLiteral "\"4\"" (MuNumber 4.0) `shouldBe` False
-      isLiteral "foo" (MuNumber 4.0) `shouldBe` False
+      isNumber 4 (MuNumber 4) `shouldBe` True
+      isNumber 4 (MuNumber 4.0) `shouldBe` True
+      isNumber 4.5 (MuNumber 4.5) `shouldBe` True
+      isNumber 4 (MuNumber 5.0) `shouldBe` False
 
     it "works with strings" $ do
-      isLiteral "\"4\"" (MuString "4") `shouldBe` True
-      isLiteral "\"hello\"" (MuString "hello") `shouldBe` True
+      isString "4" (MuString "4") `shouldBe` True
+      isString "hello" (MuString "hello") `shouldBe` True
 
     it "works with symbols" $ do
-      isLiteral "#foo" (MuSymbol "foo") `shouldBe` True
-
-      isLiteral "#foo" (MuString "foo") `shouldBe` False
+      isSymbol "foo" (MuSymbol "foo") `shouldBe` True
+      isSymbol "foo" (MuString "bar") `shouldBe` False
 
     it "works with chars" $ do
-      isLiteral "'4'" (MuChar '4') `shouldBe` True
-      isLiteral "'a'" (MuChar 'a') `shouldBe` True
-
-      isLiteral "'abc'" (MuChar 'a') `shouldBe` False
+      isChar '4' (MuChar '4') `shouldBe` True
+      isChar 'a' (MuChar 'a') `shouldBe` True
+      isChar 'a' (MuChar 'b') `shouldBe` False
 
     it "works with bools" $ do
-      isLiteral "True" (MuBool True) `shouldBe` True
-      isLiteral "False" (MuBool False) `shouldBe` True
-
-      isLiteral "True" (MuSymbol "True") `shouldBe` False
+      isBool True (MuBool True) `shouldBe` True
+      isBool False (MuBool False) `shouldBe` True
+      isBool True (MuSymbol "True") `shouldBe` False
 
     it "works with nil" $ do
-      isLiteral "Nil" MuNil `shouldBe` True
-      isLiteral "Nil" (MuString "Nil") `shouldBe` False
+      isNil MuNil `shouldBe` True
+      isNil (MuString "Nil") `shouldBe` False

--- a/src/Language/Mulang/Analyzer/ExpectationsCompiler.hs
+++ b/src/Language/Mulang/Analyzer/ExpectationsCompiler.hs
@@ -153,7 +153,7 @@ compileMatcher :: [String] -> Matcher
 compileMatcher = withEvery . f
   where
     f :: [String] -> [Inspection]
-    f ("WithFalse":args)        =  isBool True : (f args)
+    f ("WithFalse":args)        =  isBool False : (f args)
     f ("WithNil":args)          =  isNil : (f args)
     f ("WithTrue":args)         =  isBool True : (f args)
     f ("WithChar":value:args)   =  isChar (read value) : (f args)

--- a/src/Language/Mulang/Analyzer/ExpectationsCompiler.hs
+++ b/src/Language/Mulang/Analyzer/ExpectationsCompiler.hs
@@ -159,5 +159,5 @@ compileMatcher = withEvery . f
     f ("WithChar":value:args)   =  isChar (read value) : (f args)
     f ("WithNumber":value:args) =  isNumber (read value) : (f args)
     f ("WithString":value:args) =  isString (read value) : (f args)
-    f ("WithSymbol":value:args) =  isSymbol (read value) : (f args)
+    f ("WithSymbol":value:args) =  isSymbol (read ("\""++value++"\"")) : (f args)
     f []                        = []

--- a/src/Language/Mulang/Analyzer/ExpectationsCompiler.hs
+++ b/src/Language/Mulang/Analyzer/ExpectationsCompiler.hs
@@ -2,6 +2,7 @@ module Language.Mulang.Analyzer.ExpectationsCompiler(
   compileExpectation) where
 
 import Language.Mulang
+import Language.Mulang.Inspector.Literal (isNil, isNumber, isBool, isChar, isString, isSymbol)
 import Language.Mulang.Analyzer.Analysis (Expectation(..))
 
 import Data.Maybe (fromMaybe)
@@ -35,12 +36,21 @@ compileNegator ("Not":_) = negative
 compileNegator _         = id
 
 compileBaseInspection :: PredicateModifier -> [String] -> Maybe ContextualizedInspection
-compileBaseInspection p ("Not":parts)                 = compileBaseInspection p parts
-compileBaseInspection p [verb]                        = compileBaseInspection p [verb, "*"]
-compileBaseInspection p [verb, object]                = compileBaseInspection p [verb, object, "With"]
-compileBaseInspection p (verb:"With":args)            = compileBaseInspection p (verb:"*":"With":args)
-compileBaseInspection p (verb:object:"With":args)     = fmap ($ (compileObject p object)) (compileInspectionPrimitive (verb:args))
-compileBaseInspection _ _                             = Nothing
+compileBaseInspection p ("Not":parts)               = compileBaseInspection p parts
+compileBaseInspection p parts                       = compileAffirmativeInspection p parts
+
+compileAffirmativeInspection :: PredicateModifier -> [String] -> Maybe ContextualizedInspection
+compileAffirmativeInspection p [verb]                        = compileAffirmativeInspection p [verb,"*"]
+compileAffirmativeInspection p [verb,"WithFalse"]            = compileAffirmativeInspection p [verb,"*","WithFalse"]
+compileAffirmativeInspection p [verb,"WithNil"]              = compileAffirmativeInspection p [verb,"*","WithNil"]
+compileAffirmativeInspection p [verb,"WithTrue"]             = compileAffirmativeInspection p [verb,"*","WithTrue"]
+compileAffirmativeInspection p (verb:"WithChar":args)        = compileAffirmativeInspection p (verb:"*":"WithChar":args)
+compileAffirmativeInspection p (verb:"WithNumber":args)      = compileAffirmativeInspection p (verb:"*":"WithNumber":args)
+compileAffirmativeInspection p (verb:"WithString":args)      = compileAffirmativeInspection p (verb:"*":"WithString":args)
+compileAffirmativeInspection p (verb:"WithSymbol":args)      = compileAffirmativeInspection p (verb:"*":"WithSymbol":args)
+compileAffirmativeInspection p (verb:object:args)            = fmap ($ (compileObject p object)) (compileInspectionPrimitive (verb:args))
+compileAffirmativeInspection _ _                             = Nothing
+
 
 compileObject :: PredicateModifier -> String -> IdentifierPredicate
 compileObject p "*"        = p $ anyone
@@ -54,9 +64,9 @@ compileInspectionPrimitive :: [String] -> Maybe ContextualizedBoundInspection
 compileInspectionPrimitive = f
   where
   f ["Assigns"]                        = bound assigns
-  f ["Assigns", value]                 = bound (assignsMatching (with value))
+  f ("Assigns":args)                   = bound (assignsMatching (compileMatcher args))
   f ["Calls"]                          = bound calls
-  f ("Calls":args)                     = bound (callsMatching (withEvery args))
+  f ("Calls":args)                     = bound (callsMatching (compileMatcher args))
   f ["Declares"]                       = bound declares
   f ["DeclaresAttribute"]              = bound declaresAttribute
   f ["DeclaresClass"]                  = bound declaresClass
@@ -92,7 +102,7 @@ compileInspectionPrimitive = f
   f ["TypesAs"]                        = bound typesAs
   f ["TypesParameterAs"]               = bound typesParameterAs
   f ["TypesReturnAs"]                  = bound typesReturnAs
-  f ["Returns", value]                 = plain (returnsMatching (with value))
+  f ("Returns":args)                   = plain (returnsMatching (compileMatcher args))
   f ["Uses"]                           = bound uses
   f ["UsesAnonymousVariable"]          = plain usesAnonymousVariable
   f ["UsesComposition"]                = plain usesComposition
@@ -125,7 +135,7 @@ compileInspectionPrimitive = f
   f ["UsesType"]                       = bound usesType
   f ["UsesWhile"]                      = plain usesWhile
   f ["UsesYield"]                      = plain usesYield
-  f _                                = Nothing
+  f _                                  = Nothing
 
   contextualized :: ContextualizedInspection -> Maybe ContextualizedBoundInspection
   contextualized = Just . contextualizedBind
@@ -138,3 +148,16 @@ compileInspectionPrimitive = f
 
   bound :: BoundInspection -> Maybe ContextualizedBoundInspection
   bound = Just . boundContextualize
+
+compileMatcher :: [String] -> Matcher
+compileMatcher = withEvery . f
+  where
+    f :: [String] -> [Inspection]
+    f ("WithFalse":args)        =  isBool True : (f args)
+    f ("WithNil":args)          =  isNil : (f args)
+    f ("WithTrue":args)         =  isBool True : (f args)
+    f ("WithChar":value:args)   =  isChar (read value) : (f args)
+    f ("WithNumber":value:args) =  isNumber (read value) : (f args)
+    f ("WithString":value:args) =  isString (read value) : (f args)
+    f ("WithSymbol":value:args) =  isSymbol (read value) : (f args)
+    f []                        = []

--- a/src/Language/Mulang/Inspector/Literal.hs
+++ b/src/Language/Mulang/Inspector/Literal.hs
@@ -1,16 +1,33 @@
-module Language.Mulang.Inspector.Literal (isLiteral) where
+module Language.Mulang.Inspector.Literal (
+  isNil,
+  isNumber,
+  isBool,
+  isChar,
+  isString,
+  isSymbol) where
 
 import Language.Mulang.Ast
 import Language.Mulang.Inspector.Primitive (containsExpression, Inspection)
 
 import Text.Read (readMaybe)
 
-isLiteral :: Code -> Inspection
-isLiteral value = f
-  where f MuNil              = value == "Nil"
-        f (MuNumber number)  = (readMaybe value) == Just number
-        f (MuBool bool)      = (readMaybe value) == Just bool
-        f (MuString string)  = (readMaybe value) == Just string
-        f (MuChar char)      = (readMaybe value) == Just char
-        f (MuSymbol string)  = (readMaybe ("\"" ++ value ++ "\"")) == Just ("#" ++ string)
-        f _                  = False
+isNil :: Inspection
+isNil = isLiteral MuNil
+
+isNumber :: Double -> Inspection
+isNumber = isLiteral . MuNumber
+
+isBool :: Bool -> Inspection
+isBool = isLiteral . MuBool
+
+isString :: String -> Inspection
+isString = isLiteral . MuString
+
+isChar :: Char -> Inspection
+isChar = isLiteral . MuChar
+
+isSymbol :: String -> Inspection
+isSymbol = isLiteral . MuSymbol
+
+isLiteral :: Expression -> Inspection
+isLiteral = (==)

--- a/src/Language/Mulang/Inspector/Literal.hs
+++ b/src/Language/Mulang/Inspector/Literal.hs
@@ -9,8 +9,6 @@ module Language.Mulang.Inspector.Literal (
 import Language.Mulang.Ast
 import Language.Mulang.Inspector.Primitive (containsExpression, Inspection)
 
-import Text.Read (readMaybe)
-
 isNil :: Inspection
 isNil = isLiteral MuNil
 

--- a/src/Language/Mulang/Inspector/Matcher.hs
+++ b/src/Language/Mulang/Inspector/Matcher.hs
@@ -1,30 +1,23 @@
 module Language.Mulang.Inspector.Matcher (
   unmatching,
-  thatEvery,
-  that,
-  with,
   withEvery,
+  with,
   Matcher) where
 
 import           Language.Mulang.Ast
 import           Language.Mulang.Inspector.Primitive (Inspection)
-import           Language.Mulang.Inspector.Literal (isLiteral)
 
 type Matcher = [Expression] -> Bool
 
-thatEvery :: [Inspection] -> Matcher
-thatEvery inspections expressions = and (zipWith ($) inspections expressions)
+-- | Creates a simple matcher that evaluates the given inspection only againts the first of its arguments
+with :: Inspection -> Matcher
+with inspection = inspection . head
 
-that :: Inspection -> Matcher
-that inspection = inspection . head
+-- | Creates a matcher using a list of inspections
+-- The resultant matcher evaluates each inspection against each of its arguments
+withEvery :: [Inspection] -> Matcher
+withEvery inspections expressions = and (zipWith ($) inspections expressions)
 
 unmatching :: (Matcher -> b) -> b
 unmatching f = f (const True)
 
--- Special, simplified matchers
-
-with :: Code -> Matcher
-with = that . isLiteral
-
-withEvery :: [Code] -> Matcher
-withEvery = thatEvery . map isLiteral


### PR DESCRIPTION
This is non-backward compatible refactor of literal expectations, that aims them to be translated easily to natural language using https://github.com/mumuki/mumukit-inspection. 

Although this is a breaking change, I propose to be merged as a micro version, since this feature has just been released a few days ago and it should be considered still experimental. 

In the future, we should mark which packages are experimental and which not. 