### PR TITLE
Adding custom expectation results to standard list

### DIFF
--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -7,7 +7,6 @@ describe Mulang::Code do
     it { expect(code.ast).to eq "tag"=>"Assignment", "contents"=>["x", {"tag"=>"MuNumber", "contents"=>1}] }
     it { expect(code.analyse expectations: [], smellsSet: { tag: 'NoSmells' }). to eq 'tag'=>'AnalysisCompleted',
                                                                                       'intermediateLanguage'=>nil,
-                                                                                      'customExpectationResults'=>[],
                                                                                       'signatures'=>[],
                                                                                       'smells'=>[],
                                                                                       'expectationResults'=>[],

--- a/spec/CustomExpectationsAnalyzerSpec.hs
+++ b/spec/CustomExpectationsAnalyzerSpec.hs
@@ -4,12 +4,12 @@ import           Language.Mulang.Analyzer hiding (result, spec)
 import           Test.Hspec
 
 result customExpectationResults smells
-  = emptyCompletedAnalysisResult { customExpectationResults = customExpectationResults, smells = smells }
+  = emptyCompletedAnalysisResult { expectationResults = customExpectationResults, smells = smells }
 
 run language content test = analyse (customExpectationsAnalysis (CodeSample language content) test)
 
-passed message = CustomExpectationResult message True
-failed message = CustomExpectationResult message False
+passed message = customExpectationResult message True
+failed message = customExpectationResult message False
 
 nok = result [failed "E0"] []
 ok = result [passed "E0"] []

--- a/src/Language/Mulang/Analyzer.hs
+++ b/src/Language/Mulang/Analyzer.hs
@@ -30,8 +30,7 @@ analyseAst :: Expression -> AnalysisSpec -> IO AnalysisResult
 analyseAst ast spec = do
   domaingLang <- compileDomainLanguage (domainLanguage spec)
   testResults <- analyseTests ast (testAnalysisType spec)
-  return $ AnalysisCompleted (analyseExpectations ast (expectations spec))
-                             (analyseCustomExpectations ast (customExpectations spec))
+  return $ AnalysisCompleted (analyseExpectations ast (expectations spec) ++ analyseCustomExpectations ast (customExpectations spec))
                              (analyseSmells ast domaingLang (smellsSet spec))
                              (analyseSignatures ast (signatureAnalysisType spec))
                              testResults

--- a/src/Language/Mulang/Analyzer/Analysis.hs
+++ b/src/Language/Mulang/Analyzer/Analysis.hs
@@ -17,6 +17,7 @@ module Language.Mulang.Analyzer.Analysis (
   smellsAnalysis,
   testsAnalysis,
 
+  customExpectationResult,
   emptyCompletedAnalysisResult,
 
   Expectation(..),
@@ -37,8 +38,7 @@ module Language.Mulang.Analyzer.Analysis (
   TestAnalysisType(..),
 
   AnalysisResult(..),
-  ExpectationResult(..),
-  CustomExpectationResult(..)) where
+  ExpectationResult(..)) where
 
 import GHC.Generics
 
@@ -146,7 +146,6 @@ data Language
 data AnalysisResult
   = AnalysisCompleted {
       expectationResults :: [ExpectationResult],
-      customExpectationResults :: [CustomExpectationResult],
       smells :: [Expectation],
       signatures :: [Code],
       testResults :: [TestResult],
@@ -158,11 +157,6 @@ data ExpectationResult = ExpectationResult {
   result :: Bool
 } deriving (Show, Eq, Generic)
 
-
-data CustomExpectationResult = CustomExpectationResult {
-  name :: String,
-  status :: Bool
-} deriving (Show, Eq, Generic)
 
 --
 -- Builder functions
@@ -205,7 +199,10 @@ testsAnalysis :: Fragment -> TestAnalysisType -> Analysis
 testsAnalysis code testAnalysisType = Analysis code (emptyAnalysisSpec { testAnalysisType = Just testAnalysisType })
 
 emptyCompletedAnalysisResult :: AnalysisResult
-emptyCompletedAnalysisResult = AnalysisCompleted [] [] [] [] [] Nothing
+emptyCompletedAnalysisResult = AnalysisCompleted [] [] [] [] Nothing
 
 emptyDomainLanguage :: DomainLanguage
 emptyDomainLanguage = DomainLanguage Nothing Nothing Nothing Nothing
+
+customExpectationResult :: String -> Bool -> ExpectationResult
+customExpectationResult title result = ExpectationResult (Expectation "<<custom>>" title) result

--- a/src/Language/Mulang/Analyzer/Analysis/Json.hs
+++ b/src/Language/Mulang/Analyzer/Analysis/Json.hs
@@ -49,5 +49,4 @@ instance ToJSON Type
 instance ToJSON Assertion
 instance ToJSON TestResult
 instance ToJSON TestStatus
-instance ToJSON CustomExpectationResult
 instance ToJSON Operator

--- a/src/Language/Mulang/Analyzer/CustomExpectationsAnalyzer.hs
+++ b/src/Language/Mulang/Analyzer/CustomExpectationsAnalyzer.hs
@@ -4,14 +4,14 @@ module Language.Mulang.Analyzer.CustomExpectationsAnalyzer (
 import Data.Maybe (fromMaybe)
 
 import Language.Mulang
-import Language.Mulang.Analyzer.Analysis (CustomExpectationResult(..))
+import Language.Mulang.Analyzer.Analysis (customExpectationResult, ExpectationResult(..))
 import Language.Mulang.Analyzer.EdlQueryCompiler (compileTopQuery)
 
 import Language.Mulang.Edl (parseExpectations, Expectation (..))
 
-analyseCustomExpectations :: Expression -> Maybe String -> [CustomExpectationResult]
+analyseCustomExpectations :: Expression -> Maybe String -> [ExpectationResult]
 analyseCustomExpectations ast  = fromMaybe [] . fmap (map (runExpectation ast) . parseExpectations)
 
-runExpectation :: Expression -> Expectation -> CustomExpectationResult
-runExpectation ast (Expectation name q) = CustomExpectationResult name (compileTopQuery q ast)
+runExpectation :: Expression -> Expectation -> ExpectationResult
+runExpectation ast (Expectation name q) = customExpectationResult name (compileTopQuery q ast)
 


### PR DESCRIPTION
In order to allow better interopelability with original expectations. 

With this change, instead of returning a separate list, custom expectation results are reported the following way: 

```edl
test "must assign something": 
  assigns;
```

```ruby
{ expectation: { binding: "<<custom>>", inspection: "must assign something"  }, result: true }
```