### PR TITLE
Fix custom expectations i18n

### DIFF
--- a/gem/lib/mulang/code.rb
+++ b/gem/lib/mulang/code.rb
@@ -22,8 +22,7 @@ module Mulang
     end
 
     def expect(binding='*', inspection)
-      expectation = {binding: binding, inspection: inspection}
-      Mulang::Expectation.parse expectation
+      expectation = Mulang::Expectation.parse(binding: binding, inspection: inspection).as_v2.to_h
       expectation_results_for(analyse(expectations: [expectation])).first['result']
     end
 

--- a/gem/lib/mulang/expectation.rb
+++ b/gem/lib/mulang/expectation.rb
@@ -1,5 +1,4 @@
-class Mulang::Expectation
-
+module Mulang::Expectation
   SMELLS = %w(DiscardsExceptions DoesConsolePrint DoesNilTest DoesNullTest DoesTypeTest
               HasAssignmentReturn HasCodeDuplication HasEmptyIfBranches HasRedundantRepeat HasLongParameterList
               HasMisspelledBindings HasMisspelledIdentifiers
@@ -9,33 +8,10 @@ class Mulang::Expectation
               HasWrongCaseBinding HasWrongCaseIdentifiers IsLongCode OverridesEqualOrHashButNotBoth
               ReturnsNil ReturnsNull UsesCut UsesFail UsesUnificationOperator)
 
-  attr_accessor :binding, :inspection
-
-  def initialize(binding, inspection)
-    @binding = binding
-    @inspection = inspection
-  end
-
-  def check!
-    raise "Wrong binding in #{to_h}" unless binding?
-    raise "Wrong inspection #{to_h}" unless inspection?
-  end
-
-  def translate(keywords = nil)
-    return inspection.to_s if custom?
-    Mulang::Expectation::I18n.translate self, keywords
-  end
-
-  def to_h
-    {binding: binding, inspection: inspection.to_s}
-  end
-
-  def custom?
-    binding == '<<custom>>'
-  end
-
   def self.guess_type(expectation)
-    if expectation[:inspection] =~ /(Not\:)?Has.*/ && !has_smell?(expectation[:inspection])
+    if expectation[:binding] == '<<custom>>'
+      Custom
+    elsif expectation[:inspection] =~ /(Not\:)?Has.*/ && !has_smell?(expectation[:inspection])
       V0
     else
       V2
@@ -47,72 +23,14 @@ class Mulang::Expectation
   end
 
   def self.parse(expectation)
-    guess_type(expectation).new(
-      expectation[:binding],
-      Mulang::Inspection.parse(expectation[:inspection]))
+    guess_type(expectation).parse(expectation)
   end
 
   def self.valid?(expectation)
-    !!Mulang::Inspection.parse(expectation['inspection']) rescue false
-  end
-
-  class V0 < Mulang::Expectation
-    INSPECTIONS = %w(HasBinding HasTypeDeclaration HasTypeSignature HasVariable HasArity HasDirectRecursion
-                     HasComposition HasComprehension HasForeach HasIf HasGuards HasConditional HasLambda HasRepeat HasWhile
-                     HasUsage HasAnonymousVariable HasNot HasForall HasFindall)
-
-
-    def binding?
-      binding.present?
-    end
-
-    def inspection?
-      inspection.present? && INSPECTIONS.include?(inspection.type)
-    end
-
-    def as_v2
-      if has? 'Binding' then as_v2_declare ''
-      elsif has? 'TypeDeclaration' then as_v2_declare 'TypeAlias'
-      elsif has? 'TypeSignature' then as_v2_declare 'TypeSignature'
-      elsif has? 'Variable' then as_v2_declare 'Variable'
-      elsif has? 'Arity' then as_v2_declare "ComputationWithArity#{inspection.target.value}"
-      elsif has? 'DirectRecursion' then as_v2_declare "Recursively"
-      elsif has? 'Usage'
-        V2.new binding, new_inspection('Uses', Mulang::Inspection::Target.named(inspection.target.value))
-      else as_v2_use
-      end
-    end
-
-    def has?(simple_type)
-      inspection.type == "Has#{simple_type}"
-    end
-
-    def as_v2_use
-      V2.new binding, new_inspection(inspection.type.gsub('Has', 'Uses'), nil)
-    end
-
-    def as_v2_declare(simple_type)
-      V2.new '*', new_inspection("Declares#{simple_type}", Mulang::Inspection::Target.named(binding))
-    end
-
-    def new_inspection(type, target)
-      Mulang::Inspection.new(type, target, negated: inspection.negated?)
-    end
-  end
-
-  class V2 < Mulang::Expectation
-    def binding?
-      true
-    end
-
-    def inspection?
-      true
-    end
-
-    def as_v2
-      self
-    end
+    guess_type(expectation).valid?(expectation)
   end
 end
 
 require_relative './expectation/i18n'
+require_relative './expectation/custom'
+require_relative './expectation/standard'

--- a/gem/lib/mulang/expectation.rb
+++ b/gem/lib/mulang/expectation.rb
@@ -22,11 +22,16 @@ class Mulang::Expectation
   end
 
   def translate(keywords = nil)
+    return inspection.to_s if custom?
     Mulang::Expectation::I18n.translate self, keywords
   end
 
   def to_h
     {binding: binding, inspection: inspection.to_s}
+  end
+
+  def custom?
+    binding == '<<custom>>'
   end
 
   def self.guess_type(expectation)

--- a/gem/lib/mulang/expectation/custom.rb
+++ b/gem/lib/mulang/expectation/custom.rb
@@ -1,0 +1,31 @@
+class Mulang::Expectation::Custom
+  attr_accessor :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def translate(*)
+    name
+  end
+
+  def to_h
+    {binding: '<<custom>>', inspection: name}
+  end
+
+  def custom?
+    true
+  end
+
+  def standard?
+    false
+  end
+
+  def self.parse(expectation)
+    new expectation[:inspection]
+  end
+
+  def self.valid?(_)
+    true
+  end
+end

--- a/gem/lib/mulang/expectation/standard.rb
+++ b/gem/lib/mulang/expectation/standard.rb
@@ -1,0 +1,95 @@
+class Mulang::Expectation::Standard
+  attr_accessor :binding, :inspection
+
+  def initialize(binding, inspection)
+    @binding = binding
+    @inspection = inspection
+  end
+
+  def check!
+    raise "Wrong binding in #{to_h}" unless binding?
+    raise "Wrong inspection #{to_h}" unless inspection?
+  end
+
+  def translate(keywords = nil)
+    Mulang::Expectation::I18n.translate self, keywords
+  end
+
+  def to_h
+    {binding: binding, inspection: inspection.to_s}
+  end
+
+  def custom?
+    false
+  end
+
+  def standard?
+    true
+  end
+
+  def self.parse(expectation)
+    new expectation[:binding], Mulang::Inspection.parse(expectation[:inspection])
+  end
+
+  def self.valid?(expectation)
+    !!Mulang::Inspection.parse(expectation['inspection']) rescue false
+  end
+end
+
+class Mulang::Expectation::V0 < Mulang::Expectation::Standard
+  INSPECTIONS = %w(HasBinding HasTypeDeclaration HasTypeSignature HasVariable HasArity HasDirectRecursion
+                   HasComposition HasComprehension HasForeach HasIf HasGuards HasConditional HasLambda HasRepeat HasWhile
+                   HasUsage HasAnonymousVariable HasNot HasForall HasFindall)
+
+
+  def binding?
+    binding.present?
+  end
+
+  def inspection?
+    inspection.present? && INSPECTIONS.include?(inspection.type)
+  end
+
+  def as_v2
+    if has? 'Binding' then as_v2_declare ''
+    elsif has? 'TypeDeclaration' then as_v2_declare 'TypeAlias'
+    elsif has? 'TypeSignature' then as_v2_declare 'TypeSignature'
+    elsif has? 'Variable' then as_v2_declare 'Variable'
+    elsif has? 'Arity' then as_v2_declare "ComputationWithArity#{inspection.target.value}"
+    elsif has? 'DirectRecursion' then as_v2_declare "Recursively"
+    elsif has? 'Usage'
+      Mulang::Expectation::V2.new binding, new_inspection('Uses', Mulang::Inspection::Target.named(inspection.target.value))
+    else as_v2_use
+    end
+  end
+
+  def has?(simple_type)
+    inspection.type == "Has#{simple_type}"
+  end
+
+  def as_v2_use
+    Mulang::Expectation::V2.new binding, new_inspection(inspection.type.gsub('Has', 'Uses'), nil)
+  end
+
+  def as_v2_declare(simple_type)
+    Mulang::Expectation::V2.new '*', new_inspection("Declares#{simple_type}", Mulang::Inspection::Target.named(binding))
+  end
+
+  def new_inspection(type, target)
+    Mulang::Inspection.new(type, target, negated: inspection.negated?)
+  end
+end
+
+class Mulang::Expectation::V2 < Mulang::Expectation::Standard
+  def binding?
+    true
+  end
+
+  def inspection?
+    true
+  end
+
+  def as_v2
+    self
+  end
+end

--- a/gem/lib/mulang/inspection.rb
+++ b/gem/lib/mulang/inspection.rb
@@ -28,7 +28,7 @@ module Mulang
     end
 
     def to_s
-      "#{negated_to_s}#{type}#{target_to_s}"
+      "#{negated_to_s}#{type}#{target_to_s}#{matcher_to_s}"
     end
 
     def negated_to_s
@@ -37,6 +37,10 @@ module Mulang
 
     def target_to_s
       target ? ":#{target.to_s}" : nil
+    end
+
+    def matcher_to_s
+      matcher ? ":#{matcher.to_s}" : nil
     end
 
     def self.parse_binding_name(binding_s)

--- a/gem/lib/mulang/inspection/matcher.rb
+++ b/gem/lib/mulang/inspection/matcher.rb
@@ -10,6 +10,10 @@ class Mulang::Inspection::Matcher
     @value = value
   end
 
+  def to_s
+    "#{type.to_s.camelcase}#{value ? ":#{value}" : nil}"
+  end
+
   def self.parse(type, value)
     return nil unless type
     raise "Invalid matcher #{type}" unless type.in? TYPES

--- a/gem/spec/i18n_spec.rb
+++ b/gem/spec/i18n_spec.rb
@@ -76,6 +76,10 @@ describe Mulang::Expectation::I18n do
       it { expect(expectation('foo', 'HasIf').translate(keyword_repeat: 'repetir')).to eq('<strong>foo</strong> debe usar <i>if</i>') }
     end
 
+    describe 'custom expectations' do
+      it { expect(expectation('<<custom>>', 'La solución debe declarar `foo`').translate).to eq('La solución debe declarar `foo`') }
+    end
+
     describe 'v2 expectations' do
       it { expect(expectation('*', 'Declares:foo').translate).to eq('la solución debe declarar <strong>foo</strong>') }
       it { expect(expectation('*', 'DeclaresClass:foo').translate).to eq('la solución debe declarar una clase <strong>foo</strong>') }

--- a/gem/spec/inspection_spec.rb
+++ b/gem/spec/inspection_spec.rb
@@ -2,6 +2,11 @@ require_relative './spec_helper'
 
 
 describe Mulang::Inspection do
+  it { expect(Mulang::Inspection.parse('Assigns').to_s).to eq 'Assigns' }
+  it { expect(Mulang::Inspection.parse('Assigns:x').to_s).to eq 'Assigns:x' }
+  it { expect(Mulang::Inspection.parse('Assigns:WithNumber:2').to_s).to eq 'Assigns:WithNumber:2' }
+  it { expect(Mulang::Inspection.parse('Assigns:x:WithNumber:2').to_s).to eq 'Assigns:x:WithNumber:2' }
+
   it { expect(Mulang::Inspection.parse('Declares')).to json_like(type: 'Declares',
                                                                 negated: false) }
 

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -2,15 +2,18 @@ require "spec_helper"
 
 describe Mulang::Code do
   context 'when language is javascript' do
-    let(:code) { Mulang::Code.native('JavaScript', 'x = 1') }
+    let(:code) { Mulang::Code.native('JavaScript', 'var x = 1') }
 
-    it { expect(code.ast).to eq "tag"=>"Assignment", "contents"=>["x", {"tag"=>"MuNumber", "contents"=>1}] }
+    it { expect(code.ast).to eq "tag"=>"Variable", "contents"=>["x", {"tag"=>"MuNumber", "contents"=>1}] }
     it { expect(code.analyse expectations: [], smellsSet: { tag: 'NoSmells' }). to eq 'tag'=>'AnalysisCompleted',
                                                                                       'intermediateLanguage'=>nil,
                                                                                       'signatures'=>[],
                                                                                       'smells'=>[],
                                                                                       'expectationResults'=>[],
                                                                                       'testResults' => [] }
+
+    it { expect(code.expect 'x', 'HasBinding').to be true }
+    it { expect(code.expect 'y', 'HasBinding').to be false }
 
     it { expect(code.expect 'Assigns:x').to be true }
     it { expect(code.expect 'Assigns:y').to be false }


### PR DESCRIPTION
Adding support for Custom Inspections internationalization, which was missing. 

Code was refactored to support it and a bug in `expect` was fixed. 