### PR TITLE
Fix dot syntax misbehavior with transitive bindings

### DIFF
--- a/spec/ExpectationsAnalyzerSpec.hs
+++ b/spec/ExpectationsAnalyzerSpec.hs
@@ -159,3 +159,19 @@ spec = describe "ExpectationsAnalyzer" $ do
   it "works with operators" $ do
     let usesNegation = Expectation "*" "UsesNegation"
     run Haskell "x = not True" [usesNegation] `shouldReturn` (result [passed usesNegation] [])
+
+  it "works with scoped bindings" $ do
+    let birdWeightUsesPlace = Expectation "bird.weight" "Uses:place"
+    let birdPositionUsesPlace = Expectation "bird.position" "Uses:place"
+    let code = "var place = buenosAires; var bird = {position: place, weight: 20};";
+
+    run JavaScript code [birdWeightUsesPlace] `shouldReturn` (result [failed birdWeightUsesPlace] [])
+    run JavaScript code [birdPositionUsesPlace] `shouldReturn` (result [passed birdPositionUsesPlace] [])
+
+  it "works with scoped intransitive bindings" $ do
+    let birdWeightUsesPlace = Expectation "Intransitive:bird.weight" "Uses:place"
+    let birdPositionUsesPlace = Expectation "Intransitive:bird.position" "Uses:place"
+    let code = "var place = buenosAires; var bird = {position: place, weight: 20};";
+
+    run JavaScript code [birdWeightUsesPlace] `shouldReturn` (result [failed birdWeightUsesPlace] [])
+    run JavaScript code [birdPositionUsesPlace] `shouldReturn` (result [passed birdPositionUsesPlace] [])

--- a/spec/InspectorSpec.hs
+++ b/spec/InspectorSpec.hs
@@ -621,6 +621,15 @@ spec = do
     it "is False on usage in wrong method, scoped twice" $ do
       scopedList ["o", "z"] (uses (named "m")) (js "var o = {p: function(x) { m }}") `shouldBe` False
 
+    it "is True on usage in method, scoped twice" $ do
+      transitiveList ["o", "z"] (uses (named "m")) (js "var o = {z: function(x) { m }}") `shouldBe` True
+
+    it "is False on missing usage in method, scoped twice" $ do
+      transitiveList ["o", "z"] (uses (named "p")) (js "var o = {z: function(x) { m }}") `shouldBe` False
+
+    it "is False on usage in wrong method, scoped twice" $ do
+      transitiveList ["o", "z"] (uses (named "m")) (js "var o = {p: function(x) { m }}") `shouldBe` False
+
     it "is True through function application in function" $ do
       transitive "f" (uses (named "m")) (js "function g() { m }; function f(x) { g() }") `shouldBe` True
 

--- a/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
+++ b/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
@@ -26,21 +26,19 @@ compileTopQuery = fromMaybe (const True) . compileQuery
 
 compileQuery :: E.Query -> Maybe Inspection
 compileQuery (E.Decontextualize query) = compileCQuery id query >>= (return . decontextualize)
-compileQuery (E.Within name query)     | (scope, p) <- compileScope within name  = fmap (decontextualize.scope) (compileCQuery p query)
-compileQuery (E.Through name query)    | (scope, p) <- compileScope through name = fmap (decontextualize.scope) (compileCQuery p query)
+compileQuery (E.Within name query)     | (scope, p) <- compileWithin name  = fmap (decontextualize.scope) (compileCQuery p query)
+compileQuery (E.Through name query)    | (scope, p) <- compileThrough name = fmap (decontextualize.scope) (compileCQuery p query)
 compileQuery (E.Not query)             = fmap never (compileQuery query)
 compileQuery (E.And query1 query2)     = andAlso <$> (compileQuery query1) <*> (compileQuery query2)
 compileQuery (E.Or query1 query2)      = orElse <$> (compileQuery query1) <*> (compileQuery query2)
 
-compileScope f = f . splitOn "."
+compileWithin, compileThrough :: String -> Scope
+compileWithin name  = scopeFor scopedList name
+compileThrough name = scopeFor transitiveList name
 
-within, through :: [Identifier] -> Scope
-within  names       = scopeFor scopedList names
-through (names@[_]) = scopeFor transitiveList names
-through names       = scopeFor scopedList names
-
-scopeFor :: ([Identifier] -> Inspection -> Inspection) -> [Identifier] -> Scope
-scopeFor f names = (contextualized (f names), andAlso (except (last names)))
+scopeFor :: ([Identifier] -> Inspection -> Inspection) -> Identifier -> Scope
+scopeFor f name = (contextualized (f names), andAlso (except (last names)))
+  where names = splitOn "." name
 
 compileCQuery :: (IdentifierPredicate -> IdentifierPredicate) -> E.CQuery -> Maybe ContextualizedInspection
 compileCQuery pm (E.Inspection i p m) = ($ (compilePredicate pm p))         <$> compileInspection (compileVerb i) m

--- a/src/Language/Mulang/Inspector/Combiner.hs
+++ b/src/Language/Mulang/Inspector/Combiner.hs
@@ -41,6 +41,7 @@ transitive identifier inspection code = any (`scopedInspection` code) . transiti
   where scopedInspection = scoped' inspection
 
 transitiveList :: [Identifier] -> Inspection -> Inspection
-transitiveList identifiers i = transitive (last identifiers) (scopedList (init identifiers) i)
+transitiveList [identifier] i = transitive identifier i
+transitiveList identifiers i  = scopedList identifiers i
 
 scoped' = flip scoped


### PR DESCRIPTION
Fixes #249 

dot-syntax never worked - by design - with transitive inspections. So instead of making it fail silently, i am changing the implementation so it slips to scopedList when necessary