### PR TITLE
Updating js-dep version

### DIFF
--- a/spec/JavaScriptSpec.hs
+++ b/spec/JavaScriptSpec.hs
@@ -96,6 +96,11 @@ spec = do
     it "handles booleans" $ do
       js "true" `shouldBe` MuTrue
 
+    it "handles parenthesis around variables" $ do
+      js "function f() { return (x) } " `shouldBe` (SimpleFunction "f" [] (Return (Reference "x")))
+      js "var y = (x)" `shouldBe` (Variable "y" (Reference "x"))
+      js "(x)" `shouldBe` (Reference "x")
+
     it "handles negation" $ do
       js "!true" `shouldBe` (Application (Primitive Negation) [MuTrue])
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,8 +5,8 @@ extra-deps:
 # Using newest aeson, with no contents in tagged
 # unions with nullary constructors
 - aeson-1.2.1.0
-- github: erikd/language-javascript
-  commit: e65815417ffd464bfb6d5444f7ff1ad4778a9417
+- github: mumuki/language-javascript
+  commit: 3640442ea562cc125f219b5c60fbc1b77882fd62
 - github: julian-berbel/language-python
   commit: cbdf9b33cc3c30e66c8455165ed1c7d70a300a3e
 flags: {}

--- a/stack.yaml.ghcjs
+++ b/stack.yaml.ghcjs
@@ -11,8 +11,8 @@ setup-info:
 compiler-check: match-exact
 extra-deps:
 - ParsecTools-0.0.2.0
-- github: erikd/language-javascript
-  commit: e65815417ffd464bfb6d5444f7ff1ad4778a9417
+- github: mumuki/language-javascript
+  commit: 3640442ea562cc125f219b5c60fbc1b77882fd62
 - github: julian-berbel/language-python
   commit: cbdf9b33cc3c30e66c8455165ed1c7d70a300a3e
 compiler: ghcjs-0.2.1.9007019_ghc-8.0.1


### PR DESCRIPTION
This PR updates the `language-javascript` dependency, which comes with several improvement to ECMA6 support. However, the main motivation of this update is to fix a parsing bug about parenthesis around identifiers. 

I had to add a patch to our own for of this dependency since it was not compiling with `ghc-8.0.1`: https://github.com/mumuki/language-javascript/commit/1fc93bb2aec122f4eefd2fd9dc2849d9001f6ea5

Fixes #276 

