### PR TITLE
Feature interpreter refactor

### DIFF
--- a/mulang.cabal
+++ b/mulang.cabal
@@ -95,6 +95,7 @@ library
     Language.Mulang.Edl.Lexer
     Language.Mulang.Edl.Parser
     Language.Mulang.Interpreter
+    Language.Mulang.Interpreter.Internals
     Language.Mulang.Interpreter.Runner
 
   build-depends:

--- a/spec/InterpreterSpec.hs
+++ b/spec/InterpreterSpec.hs
@@ -125,12 +125,10 @@ spec = do
         lastRef (runpy "7 % 4") `shouldReturn` MuNumber 3
 
       it "evals and" $ do
-        --lastRef (runpy "true && true") `shouldReturn` MuBool True
-        pending
+        lastRef (runpy "True and True") `shouldReturn` MuBool True
 
       it "evals or" $ do
-        --lastRef (runpy "false || false") `shouldReturn` MuBool False
-        pending
+        lastRef (runpy "False or False") `shouldReturn` MuBool False
 
       it "evals comparison" $ do
         lastRef (runpy "7 > 4") `shouldReturn` MuBool True
@@ -175,5 +173,4 @@ spec = do
           a|]) `shouldReturn` MuNumber 10
 
       it "evals not" $ do
-        --lastRef (runpy "not false") `shouldReturn` MuBool True
-        pending
+        lastRef (runpy "not False") `shouldReturn` MuBool True

--- a/spec/InterpreterSpec.hs
+++ b/spec/InterpreterSpec.hs
@@ -21,6 +21,12 @@ spec :: Spec
 spec = do
   describe "evalExpr" $ do
     context "javascript" $ do
+      it "rejects logic on number" $ do
+        lastRef (runjs "1 || 2") `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Bad parameters, expected two bools but got [MuNumber 1.0,MuNumber 2.0]\"")
+
+      it "rejects math on bools" $ do
+        lastRef (runjs "true + false") `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Bad parameters, expected two numbers but got [MuBool True,MuBool False]\"")
+
       it "evals addition" $ do
         lastRef (runjs "1 + 2") `shouldReturn` MuNumber 3
 

--- a/spec/InterpreterSpec.hs
+++ b/spec/InterpreterSpec.hs
@@ -22,10 +22,10 @@ spec = do
   describe "evalExpr" $ do
     context "javascript" $ do
       it "rejects logic on number" $ do
-        lastRef (runjs "1 || 2") `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Type error: expected two bools but got [MuNumber 1.0,MuNumber 2.0]\"")
+        lastRef (runjs "1 || 2") `shouldThrow` (errorCall "Exception thrown outside try: Type error: expected two booleans but got (number) 1.0, (number) 2.0")
 
       it "rejects math on bools" $ do
-        lastRef (runjs "true + false") `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Type error: expected two numbers but got [MuBool True,MuBool False]\"")
+        lastRef (runjs "true + false") `shouldThrow` (errorCall "Exception thrown outside try: Type error: expected two numbers but got (boolean) true, (boolean) false")
 
       it "evals addition" $ do
         lastRef (runjs "1 + 2") `shouldReturn` MuNumber 3
@@ -79,7 +79,7 @@ spec = do
             }|]) `shouldReturn` MuNumber 456
 
         it "condition is non bool, fails" $ do
-          lastRef (runjs "if (6) { 123 } else { 456 }") `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Boolean expected, got: MuNumber 6.0\"")
+          lastRef (runjs "if (6) { 123 } else { 456 }") `shouldThrow` (errorCall "Exception thrown outside try: Type error: expected boolean but got (number) 6.0")
 
       it "evals functions" $ do
         lastRef (runjs [text|
@@ -93,7 +93,7 @@ spec = do
           function a() {
             function b(){}
           }
-          b()|]) `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Reference not found for name 'b'\"")
+          b()|]) `shouldThrow` (errorCall "Exception thrown outside try: Reference not found for name 'b'")
 
       it "handles whiles" $ do
         lastRef (runjs [text|
@@ -157,7 +157,7 @@ spec = do
         it "condition is non bool, fails" $ do
           lastRef (runpy [text|
             if 6: 123
-            else: 456|]) `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Boolean expected, got: MuNumber 6.0\"")
+            else: 456|]) `shouldThrow` (errorCall "Exception thrown outside try: Type error: expected boolean but got (number) 6.0")
 
       it "evals functions" $ do
         lastRef (runpy [text|

--- a/spec/InterpreterSpec.hs
+++ b/spec/InterpreterSpec.hs
@@ -22,10 +22,10 @@ spec = do
   describe "evalExpr" $ do
     context "javascript" $ do
       it "rejects logic on number" $ do
-        lastRef (runjs "1 || 2") `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Bad parameters, expected two bools but got [MuNumber 1.0,MuNumber 2.0]\"")
+        lastRef (runjs "1 || 2") `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Type error: expected two bools but got [MuNumber 1.0,MuNumber 2.0]\"")
 
       it "rejects math on bools" $ do
-        lastRef (runjs "true + false") `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Bad parameters, expected two numbers but got [MuBool True,MuBool False]\"")
+        lastRef (runjs "true + false") `shouldThrow` (errorCall "Exception thrown outside try: MuString \"Type error: expected two numbers but got [MuBool True,MuBool False]\"")
 
       it "evals addition" $ do
         lastRef (runjs "1 + 2") `shouldReturn` MuNumber 3

--- a/src/Language/Mulang/Interpreter.hs
+++ b/src/Language/Mulang/Interpreter.hs
@@ -124,29 +124,29 @@ evalExpr (M.Application (M.Primitive O.GreatherOrEqualThan) expressions) =
 evalExpr (M.Application (M.Primitive O.Modulo) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuNumber $ n1 `mod'` n2
-        f params                     = error $ "Bad parameters, expected two numbers but got " ++ show params
+        f params                     = raiseString $ "Bad parameters, expected two numbers but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.GreatherThan) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuBool $ n1 > n2
-        f params                     = error $ "Bad parameters, expected two bools but got " ++ show params
+        f params                     = raiseString $ "Bad parameters, expected two bools but got " ++ show params
 
 -- TODO make this evaluation non strict on both parameters
 evalExpr (M.Application (M.Primitive O.Or) expressions) =
   evalExpressionsWith expressions f
   where f [MuBool b1, MuBool b2] = createReference $ MuBool $ b1 || b2
-        f params                 = error $ "Bad parameters, expected two bools but got " ++ show params
+        f params                 = raiseString $ "Bad parameters, expected two bools but got " ++ show params
 
 -- TODO make this evaluation non strict on both parameters
 evalExpr (M.Application (M.Primitive O.And) expressions) =
   evalExpressionsWith expressions f
   where f [MuBool b1, MuBool b2] = createReference $ MuBool $ b1 && b2
-        f params                 = error $ "Bad parameters, expected two bools but got " ++ show params
+        f params                 = raiseString $ "Bad parameters, expected two bools but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.Negation) expressions) =
   evalExpressionsWith expressions f
   where f [MuBool b] = createReference $ MuBool $ not b
-        f params     = error $ "Bad parameters, expected one bool but got " ++ show params
+        f params     = raiseString $ "Bad parameters, expected one bool but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.Multiply) expressions) =
   evalExpressionsWith expressions f
@@ -173,10 +173,12 @@ evalExpr (M.Application (M.Primitive O.LessThan) expressions) =
 evalExpr (M.Application (M.Primitive O.Plus) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuNumber $ n1 + n2
+        f params                     = raiseString $ "Bad parameters, expected two numbers but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.Minus) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuNumber $ n1 - n2
+        f params                     = raiseString $ "Bad parameters, expected two numbers but got " ++ show params
 
 evalExpr (M.MuList expressions) = do
   refs <- forM expressions evalExpr

--- a/src/Language/Mulang/Interpreter.hs
+++ b/src/Language/Mulang/Interpreter.hs
@@ -124,29 +124,29 @@ evalExpr (M.Application (M.Primitive O.GreatherOrEqualThan) expressions) =
 evalExpr (M.Application (M.Primitive O.Modulo) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuNumber $ n1 `mod'` n2
-        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
+        f params                     = raiseTypeError "expected two numbers" params
 
 evalExpr (M.Application (M.Primitive O.GreatherThan) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuBool $ n1 > n2
-        f params                     = raiseTypeError $ "expected two bools but got " ++ show params
+        f params                     = raiseTypeError "expected two bools" params
 
 -- TODO make this evaluation non strict on both parameters
 evalExpr (M.Application (M.Primitive O.Or) expressions) =
   evalExpressionsWith expressions f
   where f [MuBool b1, MuBool b2] = createReference $ MuBool $ b1 || b2
-        f params                 = raiseTypeError $ "expected two bools but got " ++ show params
+        f params                 = raiseTypeError "expected two bools" params
 
 -- TODO make this evaluation non strict on both parameters
 evalExpr (M.Application (M.Primitive O.And) expressions) =
   evalExpressionsWith expressions f
   where f [MuBool b1, MuBool b2] = createReference $ MuBool $ b1 && b2
-        f params                 = raiseTypeError $ "expected two bools but got " ++ show params
+        f params                 = raiseTypeError "expected two bools" params
 
 evalExpr (M.Application (M.Primitive O.Negation) expressions) =
   evalExpressionsWith expressions f
   where f [MuBool b] = createReference $ MuBool $ not b
-        f params     = raiseTypeError $ "expected one bool but got " ++ show params
+        f params     = raiseTypeError "expected one bool" params
 
 evalExpr (M.Application (M.Primitive O.Multiply) expressions) =
   evalExpressionsWith expressions f
@@ -163,22 +163,22 @@ evalExpr (M.Application (M.Primitive O.NotEqual) expressions) = do
 evalExpr (M.Application (M.Primitive O.LessOrEqualThan) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuBool $ n1 <= n2
-        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
+        f params                     = raiseTypeError "expected two numbers" params
 
 evalExpr (M.Application (M.Primitive O.LessThan) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuBool $ n1 < n2
-        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
+        f params                     = raiseTypeError "expected two numbers" params
 
 evalExpr (M.Application (M.Primitive O.Plus) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuNumber $ n1 + n2
-        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
+        f params                     = raiseTypeError "expected two numbers" params
 
 evalExpr (M.Application (M.Primitive O.Minus) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuNumber $ n1 - n2
-        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
+        f params                     = raiseTypeError "expected two numbers" params
 
 evalExpr (M.MuList expressions) = do
   refs <- forM expressions evalExpr
@@ -280,8 +280,8 @@ raiseString :: String -> Executable a
 raiseString s = do
   raiseInternal =<< (createReference $ MuString s)
 
-raiseTypeError :: String -> Executable a
-raiseTypeError message = raiseString $ "Type error: " ++ message
+raiseTypeError :: String -> [Value] ->Executable a
+raiseTypeError message values = raiseString $ "Type error: " ++ message ++ " but got " ++ show values
 
 muValuesEqual r1 r2
   | r1 == r2 = createReference $ MuBool True

--- a/src/Language/Mulang/Interpreter.hs
+++ b/src/Language/Mulang/Interpreter.hs
@@ -124,29 +124,29 @@ evalExpr (M.Application (M.Primitive O.GreatherOrEqualThan) expressions) =
 evalExpr (M.Application (M.Primitive O.Modulo) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuNumber $ n1 `mod'` n2
-        f params                     = raiseString $ "Bad parameters, expected two numbers but got " ++ show params
+        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.GreatherThan) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuBool $ n1 > n2
-        f params                     = raiseString $ "Bad parameters, expected two bools but got " ++ show params
+        f params                     = raiseTypeError $ "expected two bools but got " ++ show params
 
 -- TODO make this evaluation non strict on both parameters
 evalExpr (M.Application (M.Primitive O.Or) expressions) =
   evalExpressionsWith expressions f
   where f [MuBool b1, MuBool b2] = createReference $ MuBool $ b1 || b2
-        f params                 = raiseString $ "Bad parameters, expected two bools but got " ++ show params
+        f params                 = raiseTypeError $ "expected two bools but got " ++ show params
 
 -- TODO make this evaluation non strict on both parameters
 evalExpr (M.Application (M.Primitive O.And) expressions) =
   evalExpressionsWith expressions f
   where f [MuBool b1, MuBool b2] = createReference $ MuBool $ b1 && b2
-        f params                 = raiseString $ "Bad parameters, expected two bools but got " ++ show params
+        f params                 = raiseTypeError $ "expected two bools but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.Negation) expressions) =
   evalExpressionsWith expressions f
   where f [MuBool b] = createReference $ MuBool $ not b
-        f params     = raiseString $ "Bad parameters, expected one bool but got " ++ show params
+        f params     = raiseTypeError $ "expected one bool but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.Multiply) expressions) =
   evalExpressionsWith expressions f
@@ -163,22 +163,22 @@ evalExpr (M.Application (M.Primitive O.NotEqual) expressions) = do
 evalExpr (M.Application (M.Primitive O.LessOrEqualThan) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuBool $ n1 <= n2
-        f params                     = raiseString $ "Bad parameters, expected two numbers but got " ++ show params
+        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.LessThan) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuBool $ n1 < n2
-        f params                     = raiseString $ "Bad parameters, expected two numbers but got " ++ show params
+        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.Plus) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuNumber $ n1 + n2
-        f params                     = raiseString $ "Bad parameters, expected two numbers but got " ++ show params
+        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
 
 evalExpr (M.Application (M.Primitive O.Minus) expressions) =
   evalExpressionsWith expressions f
   where f [MuNumber n1, MuNumber n2] = createReference $ MuNumber $ n1 - n2
-        f params                     = raiseString $ "Bad parameters, expected two numbers but got " ++ show params
+        f params                     = raiseTypeError $ "expected two numbers but got " ++ show params
 
 evalExpr (M.MuList expressions) = do
   refs <- forM expressions evalExpr
@@ -279,6 +279,9 @@ raiseInternal exceptionRef = do
 raiseString :: String -> Executable a
 raiseString s = do
   raiseInternal =<< (createReference $ MuString s)
+
+raiseTypeError :: String -> Executable a
+raiseTypeError message = raiseString $ "Type error: " ++ message
 
 muValuesEqual r1 r2
   | r1 == r2 = createReference $ MuBool True

--- a/src/Language/Mulang/Interpreter/Internals.hs
+++ b/src/Language/Mulang/Interpreter/Internals.hs
@@ -1,0 +1,142 @@
+module Language.Mulang.Interpreter.Internals (
+  Executable,
+  Reference (..),
+  Value (..),
+  Callback,
+  ExecutionContext (..),
+  defaultContext,
+  debug,
+  createReference,
+  dereference,
+  dereference',
+  updateRef,
+  updateGlobalObjects) where
+
+import           Language.Mulang.Ast (SubroutineBody)
+
+import           Data.Maybe (fromMaybe, fromJust)
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+
+import           Control.Monad.State.Class
+import           Control.Monad.State.Strict
+import           Control.Monad.Cont
+
+type Executable m = ContT Reference (StateT ExecutionContext IO) m
+
+newtype Reference = Reference Int deriving (Show, Eq, Ord)
+
+data Value = MuString String
+  | MuFunction [Reference] SubroutineBody
+  | MuList [Reference]
+  -- | The reference is the reference to the localScope
+  | MuNumber Double
+  | MuBool Bool
+  | MuObject (Map String Reference)
+  | MuNull
+  deriving (Show, Eq)
+
+type Callback = Reference -> Executable ()
+
+type ObjectSpace = Map Reference Value
+
+data ExecutionContext = ExecutionContext {
+  globalObjects :: ObjectSpace,
+  scopes :: [Reference],
+  currentException :: Maybe Reference,
+  currentReturnCallback :: Callback,
+  currentRaiseCallback :: Callback
+}
+
+instance Show ExecutionContext where
+  show (ExecutionContext globalObjects scopes _ _ _) =
+    "ExecutionContext { globalObjects = " ++ show globalObjects ++ ", scopes = " ++ show scopes ++ " }"
+
+-- ================================
+-- Construction of ExecutionContext
+-- ================================
+
+defaultContext :: ExecutionContext
+defaultContext = ExecutionContext {
+  globalObjects = Map.singleton (Reference 1) (MuObject Map.empty),
+  scopes = [Reference 1],
+  currentException = Nothing,
+  currentRaiseCallback = defaultRaiseCallback,
+  currentReturnCallback = defaultReturnCallback
+}
+
+defaultRaiseCallback :: Callback
+defaultRaiseCallback = \r -> do
+    v <- dereference r
+    error $ "Exception thrown outside try: " ++ asString v
+
+defaultReturnCallback :: Callback
+defaultReturnCallback = \_r -> error "Called return from outside a function"
+
+-- ================
+-- Values Debugging
+-- ================
+
+asString :: Value -> String
+asString (MuString v) = v
+asString other        = debug other
+
+debug :: Value -> String
+debug (MuString v)   = "(string) " ++ v
+debug (MuBool True)  = "(boolean) true"
+debug (MuBool False) = "(boolean) false"
+debug (MuNumber v)   = "(number) " ++ show v
+
+-- ==================
+-- Reference Creation
+-- ==================
+
+createReference :: Value -> Executable Reference
+createReference value = do
+  nextReferenceId  <- gets (fromJust . fmap incrementRef . getMaxKey . globalObjects)
+  modify (updateGlobalObjects $ Map.insert nextReferenceId value)
+  return nextReferenceId
+
+  where
+    incrementRef :: Reference -> Reference
+    incrementRef (Reference n) = Reference $ n + 1
+
+    getMaxKey :: Map k a -> Maybe k
+    getMaxKey m = case Map.maxViewWithKey m of
+      Just ((k, _a), _) -> Just k
+      _ -> Nothing
+
+-- ====================
+-- Reference Resolution
+-- ====================
+
+dereference' :: ObjectSpace -> Reference -> Value
+dereference' _ (Reference 0) = MuNull
+dereference' objectSpace ref = do
+  fromMaybe (error $ "Failed to find ref " ++ show ref ++ " in " ++ show objectSpace) .
+    Map.lookup ref $
+    objectSpace
+
+dereference :: Reference -> Executable Value
+dereference ref = do
+  objectSpace <- gets globalObjects
+  return $ dereference' objectSpace ref
+
+
+-- ================
+-- Reference Update
+-- ================
+
+updateRef :: Reference -> (Value -> Value) -> Executable ()
+updateRef ref f = do
+  val <- dereference ref
+  putRef ref (f val)
+
+  where
+    putRef :: Reference -> Value -> Executable ()
+    putRef ref = modify . updateGlobalObjects . Map.insert ref
+
+updateGlobalObjects :: (ObjectSpace -> ObjectSpace) -> ExecutionContext -> ExecutionContext
+updateGlobalObjects f context =
+  context { globalObjects = f $ globalObjects context }
+


### PR DESCRIPTION
Those are just minor refactors to the interpreter: 

* An `Internals` module has been extracted, with the internal data structures used by the interpereter
* `typeErrors` and primitive operator wrappers have being _slightly_ reifiyed

Also the python ignored tests were already passing. 

Some notes: 

* the `Internals` module contains the `ExecutionContext` and `Value` definitions which are currently core to the interpreter and exposed to any consumer of it. I am planning to hide them in the future with the introduction of a `Repl` module that complements the `Runner` module. 

Also, I want to make primitives to be easy to implement since I am planning to introduce more of them. See #286 

