### PR TITLE
Removing duplicates in smells

### DIFF
--- a/spec/SmellsAnalyzerSpec.hs
+++ b/spec/SmellsAnalyzerSpec.hs
@@ -42,6 +42,15 @@ spec = describe "SmellsAnalyzer" $ do
       runWithTypos JavaScript "function baz() {}" [Expectation "*" "Delegates:bar"] `shouldReturn` [Expectation "baz" "HasDeclarationTypos:bar"]
       runWithTypos JavaScript "function baz() {}" [Expectation "*" "SubordinatesDeclarationsTo:bar"] `shouldReturn` [Expectation "baz" "HasDeclarationTypos:bar"]
 
+    it "works when there are duplicated expectations" $ do
+      runWithTypos JavaScript "function baz() {}" [Expectation "*" "Declares:bar", Expectation "*" "Declares:bar"] `shouldReturn` [Expectation "baz" "HasDeclarationTypos:bar"]
+
+    it "works when there are duplicated expectation results" $ do
+      runWithTypos Java "class Foo {  void baz() {} }" [Expectation "*" "Declares:bar"] `shouldReturn` [Expectation "baz" "HasDeclarationTypos:bar"]
+
+    it "works when there are similar declares expectations results" $ do
+      runWithTypos Java "class Foo {  void baz() {} }" [Expectation "*" "Declares:bar", Expectation "*" "DeclaresComputationWithArity0:bar"] `shouldReturn` [Expectation "baz" "HasDeclarationTypos:bar"]
+
     it "works when there are missing declarations and multiple potential typos" $ do
       let typos = [ Expectation "Bar" "HasDeclarationTypos:bar", Expectation "baz" "HasDeclarationTypos:bar" ]
 

--- a/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
+++ b/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
@@ -30,11 +30,13 @@ type SmellInstance = (Smell, Maybe Identifier)
 -- A Detection is an executable representation of an SmellInstance
 type Detection = SmellsContext -> Expression -> [Identifier]
 
--- Smell detection has three phases:
+-- Smell detection has four phases:
 --
 -- 1. Smells selection: dependening on the given SmellSet, differents lists of smells may be generated
 -- 2. Smells instantiation: for each selected smell, one ore more concrete smells will be instantiated
 -- 3. Smells evaluation: for each smell instance, it will be evaluated and zero or more Expectations will be synthesized
+-- 4. Duplicates removal: context-sensitive smells may be activated more than once, thus nubbing is required.
+--                        The same applies to smells that apply to both declarations and type signatures
 analyseSmells :: Expression -> SmellsContext -> Maybe SmellsSet -> [Expectation]
 analyseSmells ast context = nub . concatMap (evalSmellInstance context ast) . concatMap (instantiateSmell context) . smellsFor
 

--- a/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
+++ b/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
@@ -13,7 +13,7 @@ import Language.Mulang.Edl.Expectation (cQuery, Query(..), CQuery (..), Matcher(
 
 import Language.Mulang.Analyzer.Analysis hiding (DomainLanguage, Inspection, allSmells)
 
-import Data.List ((\\), intersect, isPrefixOf)
+import Data.List ((\\), intersect, isPrefixOf, nub)
 import Data.Maybe (fromMaybe, mapMaybe)
 
 -- the runtime context of a smell analysis,
@@ -36,7 +36,7 @@ type Detection = SmellsContext -> Expression -> [Identifier]
 -- 2. Smells instantiation: for each selected smell, one ore more concrete smells will be instantiated
 -- 3. Smells evaluation: for each smell instance, it will be evaluated and zero or more Expectations will be synthesized
 analyseSmells :: Expression -> SmellsContext -> Maybe SmellsSet -> [Expectation]
-analyseSmells ast context = concatMap (evalSmellInstance context ast) . concatMap (instantiateSmell context) . smellsFor
+analyseSmells ast context = nub . concatMap (evalSmellInstance context ast) . concatMap (instantiateSmell context) . smellsFor
 
 ---
 --- Selection


### PR DESCRIPTION
Smells could be duplicated because of the following reasons:

- Context-sensitive smells could be activated more than once
- Smells that apply to type signatures would be activated twice in most cases - because of the type signature and the declaration

I am adding nub to the smells pipeline  