### PR TITLE
Improve return support

### DIFF
--- a/docs/edlspec.md
+++ b/docs/edlspec.md
@@ -370,6 +370,7 @@ expectation "The `Bar` must declare 4 or more methods related to beer or whisky"
 
 Not all inspections can be counted. Currently, only the following are supported:
 
+* `calls`
 * `declares attribute`
 * `declares class`
 * `declares function`
@@ -378,12 +379,12 @@ Not all inspections can be counted. Currently, only the following are supported:
 * `declares object`
 * `declares procedure`
 * `declares variable`
+* `returns`
 * `uses for loop`
 * `uses for`
 * `uses if`
 * `uses repeat`
 * `uses while`
-* `calls`
 
 ## Boolean operators on scoped queries
 

--- a/docs/edlspec.md
+++ b/docs/edlspec.md
@@ -356,6 +356,9 @@ expectation "must declare three subclasses of `Tax` and two subclasses of `Produ
 
 expectation "must declare no more than 4 methods in class `Queue`":
   within `Queue` count(declares method) <= 4;
+
+expectation "`max` must have 2 returns":
+  within `max` count(returns) = 2;
 ```
 
 Finally, counters may be added, using the `+` opertor:

--- a/gem/spec/i18n_spec.rb
+++ b/gem/spec/i18n_spec.rb
@@ -116,6 +116,7 @@ describe Mulang::Expectation::I18n do
 
       it { expect(expectation('foo.bar', 'DeclaresMethod').translate).to eq('<code>foo.bar</code> debe declarar métodos') }
       it { expect(expectation('foo.bar', 'UsesIf').translate).to eq('<code>foo.bar</code> debe usar <code>if</code>') }
+      it { expect(expectation('foo', 'Returns').translate).to eq('<code>foo</code> debe retornar') }
 
       it { expect(expectation('Intransitive:foo', 'Not:UsesLambda').translate).to eq('<code>foo</code> no debe emplear expresiones lambda') }
 

--- a/spec/CounterSpec.hs
+++ b/spec/CounterSpec.hs
@@ -24,3 +24,16 @@ spec = do
     it "counts across procedures" $ do
       (unmatching countIfs) (js "function f1() {if (true) {} else {}}\n\
                                 \function f2() {if (true) {} else {}}\n" ) `shouldBe` 2
+
+  describe "countReturns" $ do
+    it "counts 0" $ do
+      (unmatching countReturns) (js "") `shouldBe` 0
+      (unmatching countReturns) (js "function foo(){}") `shouldBe` 0
+
+    it "counts 1" $ do
+      (unmatching countReturns) (js "function foo() { return }" ) `shouldBe` 1
+      (unmatching countReturns) (js "function foo() { return } function foo() { }") `shouldBe` 1
+
+    it "counts 2 or more" $ do
+      (unmatching countReturns) (js "function foo() { return }\n\
+                                    \function bar() { return 4 }" ) `shouldBe` 2

--- a/spec/CustomExpectationsAnalyzerSpec.hs
+++ b/spec/CustomExpectationsAnalyzerSpec.hs
@@ -68,6 +68,14 @@ spec = describe "ExpectationsAnalyzer" $ do
     (run JavaScript "function totalAmount() { return 2 }" test) `shouldReturn` nok
     (run JavaScript "function totalAmount() { return null }" test) `shouldReturn` ok
 
+  it "evaluates returns" $ do
+    let test = "expectation: returns"
+
+    (run JavaScript "function totalAmount() { return 2 }" test) `shouldReturn` ok
+    (run JavaScript "function totalAmount() { return null }" test) `shouldReturn` ok
+    (run JavaScript "function totalAmount() { return }" test) `shouldReturn` ok
+    (run JavaScript "function totalAmount() {  }" test) `shouldReturn` nok
+
   it "evaluates returns with nil" $ do
     let test = "expectation: returns with nil"
 
@@ -157,6 +165,11 @@ spec = describe "ExpectationsAnalyzer" $ do
     (run JavaScript "if (true) {}; if (false) {}" "expectation: count (UsesIf) >= 2") `shouldReturn` ok
 
     (run JavaScript "if (true) {}; if(true) {}; if (false) {}" "expectation: count (UsesIf) >= 3") `shouldReturn` ok
+
+  it "evaluates count (returns)" $ do
+    (run JavaScript "" "expectation: count (returns) = 0") `shouldReturn` ok
+    (run JavaScript "function foo(x) { if (x) return 1 else return 3 }" "expectation: within `foo` count (returns) = 1") `shouldReturn` nok
+    (run JavaScript "function foo(x) { if (x) return 1 else return 3 }" "expectation: within `foo` count (returns) = 2") `shouldReturn` ok
 
   it "is case sensitive in standard syntax" $ do
     (run JavaScript "" "expectation: UsesIf") `shouldReturn` nok

--- a/spec/ExpectationsCompilerSpec.hs
+++ b/spec/ExpectationsCompilerSpec.hs
@@ -264,8 +264,8 @@ spec = do
     run (hs "f 3 = 3") "f" "UsesConditional" `shouldBe` False
 
   it "works with returns" $ do
-    run (js "function m() { }") "f" "Returns" `shouldBe` False
-    run (js "function m() { return 3 }") "f" "Returns" `shouldBe` True
+    run (js "function m() { }") "m" "Returns" `shouldBe` False
+    run (js "function m() { return 3 }") "m" "Returns" `shouldBe` True
 
   it "works with UsesLambda" $ do
     run (hs "f 3 = 3") "f" "UsesLambda" `shouldBe` False

--- a/spec/ExpectationsCompilerSpec.hs
+++ b/spec/ExpectationsCompilerSpec.hs
@@ -263,6 +263,10 @@ spec = do
   it "works with UsesConditional" $ do
     run (hs "f 3 = 3") "f" "UsesConditional" `shouldBe` False
 
+  it "works with returns" $ do
+    run (js "function m() { }") "f" "Returns" `shouldBe` False
+    run (js "function m() { return 3 }") "f" "Returns" `shouldBe` True
+
   it "works with UsesLambda" $ do
     run (hs "f 3 = 3") "f" "UsesLambda" `shouldBe` False
 

--- a/spec/GenericSpec.hs
+++ b/spec/GenericSpec.hs
@@ -553,6 +553,16 @@ spec = do
 
       usesIf code  `shouldBe` False
 
+  describe "returns, js" $ do
+    it "is True when returns with value" $ do
+      returns (js "function f(){ return 4 }")  `shouldBe` True
+
+    it "is True when returns without value" $ do
+      returns (js "function f(){ return }")  `shouldBe` True
+
+    it "is False when not present" $ do
+      returns (js "function f(x){ }") `shouldBe` False
+
   describe "subordinatesDeclarationsTo" $ do
     it "is True when procedure is declared and there are no other declarations" $ do
       subordinatesDeclarationsTo (named "init")  (js "function init() {}") `shouldBe` True

--- a/src/Language/Mulang/Analyzer/Autocorrector.hs
+++ b/src/Language/Mulang/Analyzer/Autocorrector.hs
@@ -109,12 +109,14 @@ inferAutocorrectionRules = buildRules . rules
       ]
     rules Java = [
         ("if", "UsesIf"),
+        ("return", "Returns"),
         ("class", "DeclaresClass"),
         ("interface", "DeclaresInterface"),
         ("for", "UsesForLoop")
       ]
     rules Ruby = [
         ("if", "UsesIf"),
+        ("return", "Returns"),
         ("class", "DeclaresClass"),
         ("def", "DeclaresComputation"),
         ("for", "UsesForeach"),
@@ -122,6 +124,7 @@ inferAutocorrectionRules = buildRules . rules
       ]
     rules Python = [
         ("if", "UsesIf"),
+        ("return", "Returns"),
         ("class", "DeclaresClass"),
         ("def", "DeclaresComputation"),
         ("for", "UsesForeach")

--- a/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
+++ b/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
@@ -72,12 +72,7 @@ compileVerb = concat . map headToUpper . words
 compileCounter :: String -> E.Matcher -> Maybe (ContextualizedBoundCounter)
 compileCounter = f
   where
-  f "UsesIf"              m            = plainMatching countIfs m
-  f "Returns"             m            = plainMatching countReturns m
-  f "UsesRepeat"          m            = plainMatching countRepeats m
-  f "UsesWhile"           m            = plainMatching countWhiles m
-  f "UsesForLoop"         m            = plainMatching countForLoops m
-  f "UsesFor"             E.Unmatching = plain countFors
+  f "Calls"               m            = boundMatching countCalls m
   f "DeclaresAttribute"   m            = boundMatching countAttributes m
   f "DeclaresClass"       m            = boundMatching countClasses m
   f "DeclaresFunction"    m            = boundMatching countFunctions m
@@ -86,7 +81,12 @@ compileCounter = f
   f "DeclaresObject"      m            = boundMatching countObjects m
   f "DeclaresProcedure"   m            = boundMatching countProcedures m
   f "DeclaresVariable"    m            = boundMatching countVariables m
-  f "Calls"               m            = boundMatching countCalls m
+  f "Returns"             m            = plainMatching countReturns m
+  f "UsesFor"             E.Unmatching = plain countFors
+  f "UsesForLoop"         m            = plainMatching countForLoops m
+  f "UsesIf"              m            = plainMatching countIfs m
+  f "UsesRepeat"          m            = plainMatching countRepeats m
+  f "UsesWhile"           m            = plainMatching countWhiles m
 
 compileInspection :: String -> E.Matcher -> Maybe ContextualizedBoundInspection
 compileInspection = f

--- a/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
+++ b/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
@@ -73,6 +73,7 @@ compileCounter :: String -> E.Matcher -> Maybe (ContextualizedBoundCounter)
 compileCounter = f
   where
   f "UsesIf"              m            = plainMatching countIfs m
+  f "Returns"             m            = plainMatching countReturns m
   f "UsesRepeat"          m            = plainMatching countRepeats m
   f "UsesWhile"           m            = plainMatching countWhiles m
   f "UsesForLoop"         m            = plainMatching countForLoops m
@@ -124,7 +125,7 @@ compileInspection = f
   f "Instantiates"                     E.Unmatching   = bound instantiates
   f "Raises"                           E.Unmatching   = bound raises
   f "Rescues"                          E.Unmatching   = bound rescues
-  f "Returns"                          m@(E.Matching _) = plainMatching returnsMatching m
+  f "Returns"                          m              = plainMatching returnsMatching m
   f "SubordinatesDeclarationsTo"       E.Unmatching   = bound subordinatesDeclarationsTo
   f "SubordinatesDeclarationsToEntryPoint" E.Unmatching = plain subordinatesDeclarationsToEntryPoint
   f "TypesAs"                          E.Unmatching   = bound typesAs

--- a/src/Language/Mulang/Inspector/Generic.hs
+++ b/src/Language/Mulang/Inspector/Generic.hs
@@ -1,13 +1,14 @@
 module Language.Mulang.Inspector.Generic (
-  countIfs,
-  countFors,
-  countFunctions,
-  countVariables,
-  countCalls,
   assigns,
   assignsMatching,
   calls,
   callsMatching,
+  countCalls,
+  countFors,
+  countFunctions,
+  countIfs,
+  countReturns,
+  countVariables,
   declares,
   declaresComputation,
   declaresComputationWithArity,
@@ -24,18 +25,19 @@ module Language.Mulang.Inspector.Generic (
   parses,
   raises,
   rescues,
+  returns,
   returnsMatching,
   subordinatesDeclarationsTo,
   subordinatesDeclarationsToEntryPoint,
   uses,
   usesAnonymousVariable,
-  usesLogic,
-  usesMath,
   usesExceptionHandling,
   usesExceptions,
   usesFor,
   usesIf,
   usesIfMatching,
+  usesLogic,
+  usesMath,
   usesPrimitive,
   usesPrint,
   usesPrintMatching,
@@ -142,9 +144,14 @@ countFors = countExpressions f
   where f (For _ _) = True
         f _         = False
 
+returns :: Inspection
+returns = unmatching returnsMatching
 
 returnsMatching :: Matcher -> Inspection
-returnsMatching matcher = containsExpression f
+returnsMatching matcher = positive (countReturns matcher)
+
+countReturns :: Matcher -> Counter
+countReturns matcher = countExpressions f
   where f (Return body) = matcher [body]
         f _             = False
 


### PR DESCRIPTION
`Returns` inspection support was quite limited - it could not be counted nor used without a matcher. This PR make it a first class citizen. 