### PR TITLE
Feature uses named self reference smell

### DIFF
--- a/spec/ObjectOrientedSpec.hs
+++ b/spec/ObjectOrientedSpec.hs
@@ -5,7 +5,6 @@ module ObjectOrientedSpec (spec) where
 import           Test.Hspec
 import           Language.Mulang.Parsers.JavaScript
 import           Language.Mulang.Parsers.Java (java)
-import           Language.Mulang.Parsers.Python (py2, py3)
 import           Language.Mulang.Ast
 import           Language.Mulang.Identifier
 import           Language.Mulang.Inspector.ObjectOriented

--- a/spec/SmellSpec.hs
+++ b/spec/SmellSpec.hs
@@ -324,6 +324,16 @@ spec = do
       shouldInvertIfCondition (javaStatement "if(true) { j++; } else { i++; }") `shouldBe` False
       shouldInvertIfCondition (js "if(true) { j++; } else { i++; }") `shouldBe` False
 
+  describe "UsesNamedSelfReference" $ do
+    it "is True when an object references itself by its name instead of using self" $ do
+      usesNamedSelfReference (js "var x = { foo: function () { return x.bar(); } }") `shouldBe` True
+
+    it "is False when an object references itself by using self" $ do
+      usesNamedSelfReference (js "var x = { foo: function () { return self.bar(); } }") `shouldBe` False
+
+    it "is False when reference is nested in another object" $ do
+      usesNamedSelfReference (Object "Aves" (Object "Pepita" (SimpleMethod "foo" [] (Reference "Aves")))) `shouldBe` False
+
   describe "hasEmptyIfBranches" $ do
     it "is True when if branch is empty but else isn't" $ do
       hasEmptyIfBranches (javaStatement "if(true) { } else { i++; }") `shouldBe` False

--- a/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
+++ b/src/Language/Mulang/Analyzer/SmellsAnalyzer.hs
@@ -83,6 +83,7 @@ allSmells = [
   "ShouldUseOtherwise",
   "UsesCut",
   "UsesFail",
+  "UsesNamedSelfReference",
   "UsesUnificationOperator" ]
 
 ---
@@ -164,8 +165,9 @@ detectionFor ("ShouldInvertIfCondition", Nothing)         = simple shouldInvertI
 detectionFor ("ShouldUseOtherwise", Nothing)              = simple shouldUseOtherwise
 detectionFor ("UsesCut", Nothing)                         = simple usesCut
 detectionFor ("UsesFail", Nothing)                        = simple usesFail
+detectionFor ("UsesNamedSelfReference", Nothing)          = simple usesNamedSelfReference
 detectionFor ("UsesUnificationOperator", Nothing)         = simple usesUnificationOperator
-detectionFor _                                      = unsupported
+detectionFor _                                            = unsupported
 
 unsupported :: Detection
 unsupported _ _ = []

--- a/src/Language/Mulang/Inspector/Generic/Smell.hs
+++ b/src/Language/Mulang/Inspector/Generic/Smell.hs
@@ -24,13 +24,15 @@ module Language.Mulang.Inspector.Generic.Smell (
   isLongCode,
   overridesEqualOrHashButNotBoth,
   returnsNil,
+  usesNamedSelfReference,
   shouldInvertIfCondition,
   shouldUseOtherwise) where
 
 import           Language.Mulang.Ast
 import qualified Language.Mulang.Ast.Operator as O
-import           Language.Mulang.Generator (Generator, identifierReferences, declaredIdentifiers, referencedIdentifiers)
+import           Language.Mulang.Generator (Generator, identifierReferences, declaredIdentifiers, referencedIdentifiers, declarations)
 import           Language.Mulang.Inspector.Primitive
+import           Language.Mulang.Inspector.Query (inspect, select)
 
 import           Data.Text.Metrics (damerauLevenshtein)
 import           Data.Text (pack)
@@ -235,3 +237,12 @@ detectTypos generator name expression | elem name identifiers = []
   where
     identifiers  = generator expression
     similar one other = damerauLevenshtein (pack one) (pack other) == 1
+
+
+usesNamedSelfReference :: Inspection
+usesNamedSelfReference expression = inspect $ do
+  Object name      objectBody <- declarations expression
+  SimpleMethod _ _ methodBody <- topLevelExpressions objectBody
+  select (elem name $ referencedIdentifiers methodBody)
+    where topLevelExpressions (Sequence es) = es
+          topLevelExpressions e             = [e]


### PR DESCRIPTION
Fixes https://github.com/mumuki/mulang/issues/296.

I've discussed this with @flbulgarelli but this is not a perfect solution, especially when it comes to ruby.

In ruby it's pretty hard to programatically pinpoint what context a certain expression is run in, such as how in:
```ruby
module Pepita
  def self.foo
    some_other_object.instance_eval { do_something_with Pepita }
  end
end
```
`Pepita` can't be replaced for `self` since that block is run in another object's context.

Yet another problem in ruby is that objects can be nested, so here:
```ruby
module Aves
  module Pepita
    self
  end
end
```

`self` references `Aves::Pepita`, and if one wanted to reference `Aves`, they'd have to do it by name.

As a compromise solution, we've decided to only look for named self references in an object's methods, and to disable this smell for metaprogramming exercises.