### PR TITLE
Feature return normalization

### DIFF
--- a/docs/clispec.md
+++ b/docs/clispec.md
@@ -486,11 +486,113 @@ $ mulang '
       ]
    }
 }
-
 ```
 
+### With normalization options
 
-## With test running
+```bash
+$ mulang '
+{
+  "sample": {
+    "tag": "MulangSample",
+    "normalizationOptions": {
+      "insertImplicitReturn": true
+    },
+    "ast": {
+      "tag": "Procedure",
+      "contents": [
+        "foo",
+        [
+          [
+            [
+              {
+                "tag": "VariablePattern",
+                "contents": "x"
+              }
+            ],
+            {
+              "tag": "UnguardedBody",
+              "contents": {
+                "tag": "Application",
+                "contents": [
+                  {
+                    "tag": "Primitive",
+                    "contents": "Multiply"
+                  },
+                  [
+                    {
+                      "tag": "MuNumber",
+                      "contents": 2
+                    },
+                    {
+                      "tag": "Reference",
+                      "contents": "x"
+                    }
+                  ]
+                ]
+              }
+            }
+          ]
+        ]
+      ]
+    }
+  },
+  "spec": {
+    "includeIntermediateLanguage": true
+  }
+}
+' | json_pp
+{
+   "tag" : "AnalysisCompleted",
+   "signatures" : [],
+   "smells" : [],
+   "expectationResults" : [],
+   "testResults" : [],
+   "intermediateLanguage" : {
+      "tag" : "Procedure",
+      "contents" : [
+         "foo",
+         [
+            [
+               [
+                  {
+                     "contents" : "x",
+                     "tag" : "VariablePattern"
+                  }
+               ],
+               {
+                  "contents" : {
+                     "tag" : "Return",
+                     "contents" : {
+                        "contents" : [
+                           {
+                              "tag" : "Primitive",
+                              "contents" : "Multiply"
+                           },
+                           [
+                              {
+                                 "tag" : "MuNumber",
+                                 "contents" : 2
+                              },
+                              {
+                                 "contents" : "x",
+                                 "tag" : "Reference"
+                              }
+                           ]
+                        ],
+                        "tag" : "Application"
+                     }
+                  },
+                  "tag" : "UnguardedBody"
+               }
+            ]
+         ]
+      ]
+   }
+}
+```
+
+### With test running
 
 ```bash
 mulang '{

--- a/docs/js/trymulang.js
+++ b/docs/js/trymulang.js
@@ -208,6 +208,55 @@ const examples = {
        "includeIntermediateLanguage" : true
     }
   },
+  "normalization": {
+    "sample": {
+      "tag": "MulangSample",
+      "normalizationOptions": {
+        "insertImplicitReturn": true
+      },
+      "ast": {
+        "tag": "Procedure",
+        "contents": [
+          "foo",
+          [
+            [
+              [
+                {
+                  "tag": "VariablePattern",
+                  "contents": "x"
+                }
+              ],
+              {
+                "tag": "UnguardedBody",
+                "contents": {
+                  "tag": "Application",
+                  "contents": [
+                    {
+                      "tag": "Primitive",
+                      "contents": "Multiply"
+                    },
+                    [
+                      {
+                        "tag": "MuNumber",
+                        "contents": 2
+                      },
+                      {
+                        "tag": "Reference",
+                        "contents": "x"
+                      }
+                    ]
+                  ]
+                }
+              }
+            ]
+          ]
+        ]
+      }
+    },
+    "spec": {
+      "includeIntermediateLanguage": true
+    }
+  },
   "testRunning" : {
     "sample" : {
        "tag" : "CodeSample",

--- a/docs/try.md
+++ b/docs/try.md
@@ -19,6 +19,7 @@
   <option value="expressiveness">With expressiveness smells</option>
   <option value="typosSmells">With typos smells</option>
   <option value="intermediate">With intermediate language generation</option>
+  <option value="normalization">With normalization options</option>
   <option value="testRunning">With test running</option>
 </select>
 </span>

--- a/gem/lib/mulang/code.rb
+++ b/gem/lib/mulang/code.rb
@@ -43,8 +43,8 @@ module Mulang
       native(*args).tap { |it| it.expect('Parses') }
     end
 
-    def self.external(content, &tool)
-      new Mulang::Language::External.new(&tool), content
+    def self.external(content, normalization_options = {},  &tool)
+      new Mulang::Language::External.new(normalization_options, &tool), content
     end
 
     def self.ast(ast)

--- a/gem/lib/mulang/language.rb
+++ b/gem/lib/mulang/language.rb
@@ -25,7 +25,8 @@ module Mulang::Language
   end
 
   class External
-    def initialize(&tool)
+    def initialize(normalization_options = {}, &tool)
+      @normalization_options = normalization_options
       @tool = block_given? ? tool : proc { |it| it }
     end
 
@@ -36,6 +37,7 @@ module Mulang::Language
     def sample(content)
       {
         tag: 'MulangSample',
+        normalizationOptions: @normalization_options,
         ast: ast(content)
       }
     end

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -84,4 +84,25 @@ describe Mulang::Code do
 
     it { expect { code.analyse(spec) }.not_to raise_error }
   end
+
+  context 'when language is external with normalization options' do
+    let(:input) { { tag: :MuNumber, contents: 1 } }
+    let(:code) { Mulang::Code.external(input, insertImplicitReturn: true) }
+
+    it do
+      expect(code.sample).to eq tag: 'MulangSample',
+                                ast: {tag: :MuNumber, contents: 1},
+                                normalizationOptions: {insertImplicitReturn: true}
+    end
+
+    it do
+      expect(code.analyse(includeIntermediateLanguage: true)).to eq 'expectationResults' => [],
+                                                                    'intermediateLanguage' => {'tag'=>'MuNumber', 'contents'=>1},
+                                                                    'signatures' => [],
+                                                                    'smells' => [],
+                                                                    'tag' => 'AnalysisCompleted',
+                                                                    'testResults' => []
+
+    end
+  end
 end

--- a/ghcjslib/src/code.js
+++ b/ghcjslib/src/code.js
@@ -14,8 +14,12 @@
   }
 
   class MulangExternalLanguage {
+    constructor(normalizationOptions = {}) {
+      this.normalizationOptions = normalizationOptions;
+    }
+
     sample(content) {
-      return { tag: 'MulangSample', ast: content };
+      return { tag: 'MulangSample', ast: content, normalizationOptions: this.normalizationOptions };
     }
 
     ast(code) {

--- a/src/Data/List/Extra.hs
+++ b/src/Data/List/Extra.hs
@@ -1,7 +1,8 @@
 module Data.List.Extra (
   headOrElse,
   has,
-  dropLast) where
+  dropLast,
+  unwind) where
 
 headOrElse :: a -> [a] -> a
 headOrElse x []     = x
@@ -12,3 +13,7 @@ has f g = any f . g
 
 dropLast :: Int -> String -> String
 dropLast n xs = take (length xs - n) xs
+
+unwind :: [a] -> Maybe ([a], a)
+unwind [] = Nothing
+unwind xs = Just (init xs, last xs)

--- a/src/Language/Mulang/Analyzer/Analysis/Json.hs
+++ b/src/Language/Mulang/Analyzer/Analysis/Json.hs
@@ -1,9 +1,11 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Language.Mulang.Analyzer.Analysis.Json () where
 
 import           Data.Aeson
 import           Language.Mulang
 import           Language.Mulang.Analyzer.Analysis
-import           Language.Mulang.Builder (NormalizationOptions, SequenceSortMode)
+import           Language.Mulang.Builder (NormalizationOptions (..), SequenceSortMode, defaultNormalizationOptions)
 import           Language.Mulang.Interpreter.Runner (TestResult, TestStatus)
 
 instance FromJSON Analysis
@@ -18,7 +20,16 @@ instance FromJSON CaseStyle
 instance FromJSON SignatureAnalysisType
 instance FromJSON SignatureStyle
 
-instance FromJSON NormalizationOptions
+instance FromJSON NormalizationOptions where
+    parseJSON = withObject "NormalizationOptions" $ \v -> NormalizationOptions
+        <$> v .:?  "convertObjectVariableIntoObject"              .!= convertObjectVariableIntoObject d
+        <*> v .:? "convertLambdaVariableIntoFunction"             .!= convertLambdaVariableIntoFunction d
+        <*> v .:? "convertObjectLevelFunctionIntoMethod"          .!= convertObjectLevelFunctionIntoMethod d
+        <*> v .:? "convertObjectLevelLambdaVariableIntoMethod"    .!= convertObjectLevelLambdaVariableIntoMethod d
+        <*> v .:? "convertObjectLevelVariableIntoAttribute"       .!= convertObjectLevelVariableIntoAttribute d
+        <*> v .:? "sortSequenceDeclarations"                      .!= sortSequenceDeclarations d
+        <*> v .:? "insertImplicitReturn"                          .!= insertImplicitReturn d
+          where d = defaultNormalizationOptions
 instance FromJSON SequenceSortMode
 
 instance FromJSON Fragment

--- a/src/Language/Mulang/Builder.hs
+++ b/src/Language/Mulang/Builder.hs
@@ -14,6 +14,7 @@ module Language.Mulang.Builder (
 import           GHC.Generics
 
 import Data.List (sort, nub)
+import Data.List.Extra (unwind)
 
 import Language.Mulang.Ast
 import Language.Mulang.Generator (declarators, declaredIdentifiers)
@@ -117,9 +118,10 @@ normalizeBodyWith :: NormalizationOptions -> Expression -> Expression
 normalizeBodyWith ops = normalizeReturnWith ops . normalizeWith ops
 
 normalizeReturnWith :: NormalizationOptions -> Expression -> Expression
-normalizeReturnWith ops e | not . insertImplicitReturn $ ops = e
-normalizeReturnWith _   e | isImplicitReturn e = Return e
-normalizeReturnWith _   e = e
+normalizeReturnWith ops e             | not $ insertImplicitReturn ops = e
+normalizeReturnWith _   e             | isImplicitReturn e = Return e
+normalizeReturnWith _   (Sequence es) | Just (i, l) <- unwind es, isImplicitReturn l = Sequence $ i ++ [Return l]
+normalizeReturnWith _   e             = e
 
 isImplicitReturn :: Expression -> Bool
 isImplicitReturn (Reference _)         = True

--- a/src/Language/Mulang/Inspector/Literal.hs
+++ b/src/Language/Mulang/Inspector/Literal.hs
@@ -10,7 +10,11 @@ module Language.Mulang.Inspector.Literal (
   isLogic,
   isMath,
   isLiteral,
+  isSimple,
+  isCompound,
   isNonliteral) where
+
+import Data.Function.Extra (orElse)
 
 import Language.Mulang.Ast
 import Language.Mulang.Ast.Operator (Operator (..))
@@ -54,14 +58,24 @@ isLogic (Primitive Or)       = True
 isLogic _                    = False
 
 isLiteral :: Inspection
-isLiteral (MuBool _)   = True
-isLiteral (MuChar _)   = True
-isLiteral (MuNumber _) = True
-isLiteral (MuString _) = True
-isLiteral (MuSymbol _) = True
-isLiteral MuNil        = True
-isLiteral Self         = True
-isLiteral _            = False
+isLiteral = isSimple `orElse` isCompound
+
+isSimple :: Inspection
+isSimple (MuBool _)   = True
+isSimple (MuChar _)   = True
+isSimple (MuNumber _) = True
+isSimple (MuString _) = True
+isSimple (MuSymbol _) = True
+isSimple MuNil        = True
+isSimple Self         = True
+isSimple _            = False
+
+isCompound :: Inspection
+isCompound (MuDict   _) = True
+isCompound (MuList   _) = True
+isCompound (MuObject _) = True
+isCompound (MuTuple  _) = True
+isCompound _            = False
 
 isNonliteral :: Inspection
 isNonliteral = not . isLiteral


### PR DESCRIPTION
# :dart: Goal 

To allow to introduce implicit returns in some languages - e.g. ruby. 

# :eyes: See

* https://github.com/mumuki/mulang/issues/295