### PR TITLE
Feature renamer

### DIFF
--- a/mulang.cabal
+++ b/mulang.cabal
@@ -39,7 +39,6 @@ library
     Language.Mulang.Ast.Operator
     Language.Mulang.Ast.Visitor
     Language.Mulang.Builder
-    Language.Mulang.Renamer
     Language.Mulang.Consult
     Language.Mulang.Counter
     Language.Mulang.DomainLanguage
@@ -104,6 +103,8 @@ library
     Language.Mulang.Interpreter
     Language.Mulang.Interpreter.Internals
     Language.Mulang.Interpreter.Runner
+    Language.Mulang.Transform.Normalizer
+    Language.Mulang.Transform.Renamer
 
   build-depends:
     base                      <= 5,

--- a/mulang.cabal
+++ b/mulang.cabal
@@ -37,6 +37,7 @@ library
     Language.Mulang
     Language.Mulang.Ast
     Language.Mulang.Ast.Operator
+    Language.Mulang.Ast.Visitor
     Language.Mulang.Builder
     Language.Mulang.Renamer
     Language.Mulang.Consult

--- a/mulang.cabal
+++ b/mulang.cabal
@@ -38,6 +38,7 @@ library
     Language.Mulang.Ast
     Language.Mulang.Ast.Operator
     Language.Mulang.Builder
+    Language.Mulang.Renamer
     Language.Mulang.Consult
     Language.Mulang.Counter
     Language.Mulang.DomainLanguage

--- a/spec/AnalysisJsonSpec.hs
+++ b/spec/AnalysisJsonSpec.hs
@@ -11,7 +11,7 @@ import           Language.Mulang.Analyzer.Analysis.Json ()
 import           Language.Mulang.Analyzer hiding (spec)
 import           Language.Mulang.Ast
 import           Language.Mulang.Ast.Operator (Operator(..))
-import           Language.Mulang.Builder (NormalizationOptions (..), defaultNormalizationOptions)
+import           Language.Mulang.Transform.Normalizer (NormalizationOptions (..), defaultNormalizationOptions)
 
 import           Data.Maybe (fromJust)
 import           Data.Aeson (decode)

--- a/spec/NormalizerSpec.hs
+++ b/spec/NormalizerSpec.hs
@@ -1,13 +1,13 @@
-module NormalizationSpec (spec) where
+module NormalizerSpec (spec) where
 
   import           Test.Hspec
   import           Language.Mulang.Ast
   import           Language.Mulang.Ast.Operator
-  import           Language.Mulang.Builder
-  import           Language.Mulang.Parsers.Java (java)
-  import           Language.Mulang.Parsers.Python (py)
   import           Language.Mulang.Parsers.Haskell (hs)
+  import           Language.Mulang.Parsers.Java (java)
   import           Language.Mulang.Parsers.JavaScript (js)
+  import           Language.Mulang.Parsers.Python (py)
+  import           Language.Mulang.Transform.Normalizer
 
   spec :: Spec
   spec = do

--- a/spec/RenamerSpec.hs
+++ b/spec/RenamerSpec.hs
@@ -2,7 +2,7 @@ module RenamerSpec (spec) where
 
 import           Test.Hspec
 import           Language.Mulang.Ast
-import           Language.Mulang.Renamer (rename)
+import           Language.Mulang.Transform.Renamer (rename)
 import           Language.Mulang.Parsers.JavaScript (js)
 
 spec :: Spec

--- a/spec/RenamerSpec.hs
+++ b/spec/RenamerSpec.hs
@@ -1,0 +1,50 @@
+module RenamerSpec (spec) where
+
+import           Test.Hspec
+import           Language.Mulang.Ast
+import           Language.Mulang.Renamer (rename)
+import           Language.Mulang.Parsers.JavaScript (js)
+
+spec :: Spec
+spec = do
+  describe "rename" $ do
+    it "renames empty asts" $ do
+      (rename (js "")) `shouldBe` None
+
+    it "renames single var" $ do
+      (rename (js "let x = 1")) `shouldBe` (js "let mulang_var_n0 = 1")
+
+    it "renames two vars" $ do
+      (rename (js "let x = 1; let y = 2;")) `shouldBe` (js "let mulang_var_n0 = 1; let mulang_var_n1 = 2;")
+
+    it "renames three vars" $ do
+      (rename (js "let x = 1; let y = 2; let z = 3;")) `shouldBe` (
+        js "let mulang_var_n0 = 1; let mulang_var_n1 = 2; let mulang_var_n2 = 3;")
+
+    it "renames references" $ do
+      (rename (js "let x = 1; console.log(x * 2)")) `shouldBe` (js "let mulang_var_n0 = 1; console.log(mulang_var_n0 * 2)")
+
+    it "renames three vars with references" $ do
+      (rename (js "let x = 1; let y = 2; let z = x + f(y);")) `shouldBe` (
+        js "let mulang_var_n0 = 1; let mulang_var_n1 = 2; let mulang_var_n2 = mulang_var_n0 + f(mulang_var_n1);")
+
+    it "does not rename unknown references" $ do
+      (rename (js "console.log(x * 2)")) `shouldBe` (js "console.log(x * 2)")
+
+    it "renames single param" $ do
+      (rename (js "function f(x) {}")) `shouldBe` (js "function f(mulang_param_n0) {}")
+
+    it "renames multiple param" $ do
+      (rename (js "function f(x, y) {}")) `shouldBe` (js "function f(mulang_param_n0, mulang_param_n1) {}")
+
+    it "renames multiple params with references" $ do
+      (rename (js "function f(x, y) { return x + y }")) `shouldBe` (
+        js "function f(mulang_param_n0, mulang_param_n1) { return mulang_param_n0 + mulang_param_n1 }")
+
+    it "renames multiple params with mixed references" $ do
+      (rename (js "let y = 0; function f(x) { return x + y }")) `shouldBe` (
+        js "let mulang_var_n0 = 0; function f(mulang_param_n0) { return mulang_param_n0 + mulang_var_n0 }")
+
+    it "resets references renames across multiple computations" $ do
+      (rename (js "function f(x) { return 2 * x }; function g(x) { return 2 * x };")) `shouldBe` (
+        js "function f(mulang_param_n0) { return 2 * mulang_param_n0 }; function g(mulang_param_n0) { return 2 * mulang_param_n0 }")

--- a/src/Language/Mulang/Analyzer/Analysis.hs
+++ b/src/Language/Mulang/Analyzer/Analysis.hs
@@ -46,7 +46,7 @@ import GHC.Generics
 
 import Language.Mulang.Ast
 import Language.Mulang.Edl.Expectation (Query)
-import Language.Mulang.Builder (NormalizationOptions)
+import Language.Mulang.Transform.Normalizer (NormalizationOptions)
 import Language.Mulang.Interpreter.Runner (TestResult)
 import Data.Map.Strict (Map)
 

--- a/src/Language/Mulang/Analyzer/Analysis/Json.hs
+++ b/src/Language/Mulang/Analyzer/Analysis/Json.hs
@@ -5,7 +5,7 @@ module Language.Mulang.Analyzer.Analysis.Json () where
 import           Data.Aeson
 import           Language.Mulang
 import           Language.Mulang.Analyzer.Analysis
-import           Language.Mulang.Builder (NormalizationOptions (..), SequenceSortMode, defaultNormalizationOptions)
+import           Language.Mulang.Transform.Normalizer (NormalizationOptions (..), SequenceSortMode, defaultNormalizationOptions)
 import           Language.Mulang.Interpreter.Runner (TestResult, TestStatus)
 
 instance FromJSON Analysis

--- a/src/Language/Mulang/Analyzer/FragmentParser.hs
+++ b/src/Language/Mulang/Analyzer/FragmentParser.hs
@@ -13,7 +13,7 @@ import        Language.Mulang.Parsers.Prolog (parseProlog)
 import        Language.Mulang.Parsers.Java (parseJava)
 import        Language.Mulang.Parsers.Python (parsePython, parsePython2, parsePython3)
 import        Language.Mulang.Analyzer.Analysis (Fragment(..), Language(..))
-import        Language.Mulang.Builder (normalize, normalizeWith, NormalizationOptions)
+import        Language.Mulang.Transform.Normalizer (normalize, normalizeWith, NormalizationOptions)
 
 parseFragment' :: Fragment -> Expression
 parseFragment' = orFail . parseFragment

--- a/src/Language/Mulang/Ast/Visitor.hs
+++ b/src/Language/Mulang/Ast/Visitor.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveGeneric, PatternSynonyms, ViewPatterns #-}
+{-# LANGUAGE PatternSynonyms, ViewPatterns #-}
 
 module Language.Mulang.Ast.Visitor (
     pattern Terminal,
@@ -12,6 +12,30 @@ module Language.Mulang.Ast.Visitor (
   ) where
 
 import Language.Mulang.Ast
+
+-- By using this module, AST can be visited with less effort using the following strategy:
+--
+-- --
+-- (ProblemSpecificPatterns)
+-- --
+-- (Assert b a)
+-- (For stmts e)
+-- (ForLoop e1 e2 e3 e4)
+-- (Lambda ps e)
+-- (Match e eqs)
+-- (Rule i ps es)
+-- (Send e1 e2 es)
+-- (Switch e1 ps e2)
+-- (Try t cs f)
+-- --
+-- (ExpressionAndExpressionsList e1 es _)
+-- (SingleEquationsList es _)
+-- (SingleExpression e1 _)
+-- (SingleExpressionsList es _)
+-- (SinglePatternsList es _)
+-- (ThreeExpressions e1 e2 e3 _)
+-- (TwoExpressions e1 e2 _)
+-- Terminal
 
 pattern Terminal <- (extractTerminal -> Just _)
 
@@ -119,26 +143,3 @@ extractExpressionAndExpressionsList :: Expression -> Maybe (Expression, [Express
 extractExpressionAndExpressionsList (Application e1 es) = Just (e1, es, Application)
 extractExpressionAndExpressionsList (New e1 es)         = Just (e1, es, New)
 extractExpressionAndExpressionsList _                   = Nothing
-
--- --
--- ProblemSpecific
--- --
--- (Assert b a)
--- (For stmts e)
--- (ForLoop e1 e2 e3 e4)
--- (Lambda ps e)
--- (Match e eqs)
--- (Rule i ps es)
--- (Send e1 e2 es)
--- (Switch e1 ps e2)
--- (Try t cs f)
--- --
--- (ExpressionAndExpressionsList e1 es _)
--- (SingleEquationsList es _)
--- (SingleExpression e1 _)
--- (SingleExpressionsList es _)
--- (SinglePatternsList es _)
--- (Terminal)
--- (ThreeExpressions e1 e2 e3 _)
--- (TwoExpressions e1 e2 _)
-

--- a/src/Language/Mulang/Ast/Visitor.hs
+++ b/src/Language/Mulang/Ast/Visitor.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE DeriveGeneric, PatternSynonyms, ViewPatterns #-}
+
+module Language.Mulang.Ast.Visitor (
+    pattern Terminal,
+    pattern SingleExpression,
+    pattern TwoExpressions,
+    pattern ThreeExpressions,
+    pattern SingleExpressionsList,
+    pattern SingleEquationsList,
+    pattern SinglePatternsList,
+    pattern ExpressionAndExpressionsList
+  ) where
+
+import Language.Mulang.Ast
+
+pattern Terminal <- (extractTerminal -> Just _)
+
+extractTerminal :: Expression -> Maybe ()
+extractTerminal (Enumeration _ _)   = Just ()
+extractTerminal (MuBool _)          = Just ()
+extractTerminal (MuChar _)          = Just ()
+extractTerminal (MuNumber _)        = Just ()
+extractTerminal (MuString _)        = Just ()
+extractTerminal (MuSymbol _)        = Just ()
+extractTerminal (Other _ Nothing)   = Just ()
+extractTerminal (Primitive _)       = Just ()
+extractTerminal (Record _)          = Just ()
+extractTerminal (Reference _)       = Just ()
+extractTerminal (TypeAlias _ _)     = Just ()
+extractTerminal (TypeSignature _ _) = Just ()
+extractTerminal Equal               = Just ()
+extractTerminal MuNil               = Just ()
+extractTerminal None                = Just ()
+extractTerminal NotEqual            = Just ()
+extractTerminal Self                = Just ()
+extractTerminal _                   = Nothing
+
+pattern SingleExpression e1 c <- (extractSingleExpression -> Just (e1, c))
+
+extractSingleExpression :: Expression -> Maybe (Expression, Expression -> Expression)
+extractSingleExpression (Assignment v1 e)        = Just (e, \e -> (Assignment v1 e))
+extractSingleExpression (Attribute v1 e)         = Just (e, \e -> (Attribute v1 e))
+extractSingleExpression (Break e)                = Just (e, \e -> (Break e))
+extractSingleExpression (Class v1 v2 e)          = Just (e, \e -> (Class v1 v2 e))
+extractSingleExpression (Constant v1 e)          = Just (e, \e -> (Constant v1 e))
+extractSingleExpression (Continue e)             = Just (e, \e -> (Continue e))
+extractSingleExpression (EntryPoint v1 e)        = Just (e, \e -> (EntryPoint v1 e))
+extractSingleExpression (FieldReference e v1)    = Just (e, \e -> (FieldReference e v1))
+extractSingleExpression (Implement e)            = Just (e, \e -> (Implement e))
+extractSingleExpression (Include e)              = Just (e, \e -> (Include e))
+extractSingleExpression (Interface v1 v2 e)      = Just (e, \e -> (Interface v1 v2 e))
+extractSingleExpression (MuDict e)               = Just (e, \e -> (MuDict e))
+extractSingleExpression (MuObject e)             = Just (e, \e -> (MuObject e))
+extractSingleExpression (Not e)                  = Just (e, \e -> (Not e))
+extractSingleExpression (Object v1 e)            = Just (e, \e -> (Object v1 e))
+extractSingleExpression (Other v1 (Just e))      = Just (e, \e -> (Other v1 (Just e)))
+extractSingleExpression (Print e)                = Just (e, \e -> (Print e))
+extractSingleExpression (Raise e)                = Just (e, \e -> (Raise e))
+extractSingleExpression (Return e)               = Just (e, \e -> (Return e))
+extractSingleExpression (TypeCast e v1)          = Just (e, \e -> (TypeCast e v1))
+extractSingleExpression (Variable v1 e)          = Just (e, \e -> (Variable v1 e))
+extractSingleExpression (Yield e)                = Just (e, \e -> (Yield e))
+extractSingleExpression _                        = Nothing
+
+pattern TwoExpressions e1 e2 c <- (extractTwoExpressions -> Just (e1, e2, c))
+
+extractTwoExpressions :: Expression -> Maybe (Expression, Expression,
+                                              Expression -> Expression -> Expression)
+extractTwoExpressions (Arrow e1 e2)               = Just (e1, e2, \e1 e2 -> (Arrow e1 e2))
+extractTwoExpressions (FieldAssignment e1 v1 e2)  = Just (e1, e2, \e1 e2 -> (FieldAssignment e1 v1 e2))
+extractTwoExpressions (Forall e1 e2)              = Just (e1, e2, \e1 e2 -> (Forall e1 e2))
+extractTwoExpressions (Repeat e1 e2)              = Just (e1, e2, \e1 e2 -> (Repeat e1 e2))
+extractTwoExpressions (Test e1 e2)                = Just (e1, e2, \e1 e2 -> (Test e1 e2))
+extractTwoExpressions (TestGroup e1 e2)           = Just (e1, e2, \e1 e2 -> (TestGroup e1 e2))
+extractTwoExpressions (While e1 e2)               = Just (e1, e2, \e1 e2 -> (While e1 e2))
+extractTwoExpressions _                           = Nothing
+
+pattern ThreeExpressions e1 e2 e3 c <- (extractThreeExpressions -> Just (e1, e2, e3, c))
+
+extractThreeExpressions :: Expression -> Maybe (Expression, Expression, Expression,
+                                                Expression -> Expression -> Expression -> Expression)
+extractThreeExpressions (Findall e1 e2 e3) = Just (e1, e2, e3, Findall)
+extractThreeExpressions (If e1 e2 e3)      = Just (e1, e2, e3, If)
+extractThreeExpressions _                  = Nothing
+
+pattern SingleExpressionsList es c <- (extractSingleExpressionsList -> Just (es, c))
+
+extractSingleExpressionsList :: Expression -> Maybe ([Expression],
+                                                     [Expression] -> Expression)
+extractSingleExpressionsList (MuList es)   = Just (es, MuList)
+extractSingleExpressionsList (MuTuple es)  = Just (es, MuTuple)
+extractSingleExpressionsList (Sequence es) = Just (es, Sequence)
+extractSingleExpressionsList _               = Nothing
+
+pattern SingleEquationsList es e <- (extractSingleEquationsList -> Just (es, e))
+
+extractSingleEquationsList :: Expression -> Maybe ([Equation],
+                                                   [Equation] -> Expression)
+extractSingleEquationsList (EqualMethod eqs)       = Just (eqs, (EqualMethod))
+extractSingleEquationsList (Function v eqs)        = Just (eqs, (Function v))
+extractSingleEquationsList (HashMethod eqs)        = Just (eqs, (HashMethod))
+extractSingleEquationsList (Method v eqs)          = Just (eqs, (Method v))
+extractSingleEquationsList (PrimitiveMethod v eqs) = Just (eqs, (PrimitiveMethod v))
+extractSingleEquationsList (Procedure v eqs)       = Just (eqs, (Procedure v))
+extractSingleEquationsList _                       = Nothing
+
+pattern SinglePatternsList es c <- (extractSinglePatternsList -> Just (es, c))
+
+extractSinglePatternsList :: Expression -> Maybe ([Pattern],
+                                                  [Pattern] -> Expression)
+extractSinglePatternsList (Exist v ps) = Just (ps, (Exist v))
+extractSinglePatternsList (Fact v ps)  = Just (ps, (Fact v))
+extractSinglePatternsList _              = Nothing
+
+pattern ExpressionAndExpressionsList e1 es c <- (extractExpressionAndExpressionsList -> Just (e1, es, c))
+
+extractExpressionAndExpressionsList :: Expression -> Maybe (Expression, [Expression],
+                                                            Expression -> [Expression] -> Expression)
+extractExpressionAndExpressionsList (Application e1 es) = Just (e1, es, Application)
+extractExpressionAndExpressionsList (New e1 es)         = Just (e1, es, New)
+extractExpressionAndExpressionsList _                   = Nothing
+
+-- --
+-- ProblemSpecific
+-- --
+-- (Assert b a)
+-- (For stmts e)
+-- (ForLoop e1 e2 e3 e4)
+-- (Lambda ps e)
+-- (Match e eqs)
+-- (Rule i ps es)
+-- (Send e1 e2 es)
+-- (Switch e1 ps e2)
+-- (Try t cs f)
+-- --
+-- (ExpressionAndExpressionsList e1 es _)
+-- (SingleEquationsList es _)
+-- (SingleExpression e1 _)
+-- (SingleExpressionsList es _)
+-- (SinglePatternsList es _)
+-- (Terminal)
+-- (ThreeExpressions e1 e2 e3 _)
+-- (TwoExpressions e1 e2 _)
+

--- a/src/Language/Mulang/Builder.hs
+++ b/src/Language/Mulang/Builder.hs
@@ -17,6 +17,7 @@ import Data.List (sort, nub)
 import Data.List.Extra (unwind)
 
 import Language.Mulang.Ast
+import Language.Mulang.Ast.Visitor
 import Language.Mulang.Generator (declarators, declaredIdentifiers)
 import Language.Mulang.Inspector.Literal (isLiteral)
 
@@ -70,60 +71,56 @@ normalize :: Expression -> Expression
 normalize = normalizeWith defaultNormalizationOptions
 
 normalizeWith :: NormalizationOptions -> Expression -> Expression
-normalizeWith ops (Application (Send r m []) args) = Send (normalizeWith ops r) (normalizeWith ops m) (mapNormalizeWith ops args)
-normalizeWith ops (Application e es)               = Application (normalizeWith ops e) (mapNormalizeWith ops es)
-normalizeWith ops (Arrow e1 e2)                    = Arrow (normalizeWith ops e1) (normalizeWith ops e2)
-normalizeWith ops (Attribute n e)                  = Attribute n (normalizeWith ops e)
-normalizeWith _   (Fact n args)                    = Fact n args
-normalizeWith ops (For stms e1)                    = For stms (normalizeWith ops e1)
-normalizeWith ops (Forall e1 e2)                   = Forall (normalizeWith ops e1) (normalizeWith ops e2)
-normalizeWith ops (ForLoop init cond prog stmt)    = ForLoop (normalizeWith ops init) (normalizeWith ops cond) (normalizeWith ops prog) (normalizeWith ops stmt)
-normalizeWith ops (Function n equations)           = Function n (mapNormalizeEquationWith ops equations)
-normalizeWith ops (If e1 e2 e3)                    = If (normalizeWith ops e1) (normalizeWith ops e2) (normalizeWith ops e3)
-normalizeWith ops (Lambda ps e2)                   = Lambda ps (normalizeWith ops e2)
-normalizeWith ops (Match e1 equations)             = Match (normalizeWith ops e1) (mapNormalizeEquationWith ops equations)
-normalizeWith ops (Method n equations)             = Method n (mapNormalizeEquationWith ops equations)
-normalizeWith ops (MuDict e)                       = MuDict (normalizeWith ops e)
-normalizeWith ops (MuList es)                      = MuList (mapNormalizeWith ops es)
-normalizeWith ops (MuObject e)                     = MuObject (normalizeWith ops e)
-normalizeWith ops (MuTuple es)                     = MuTuple (mapNormalizeWith ops es)
-normalizeWith ops (Not e)                          = Not (normalizeWith ops e)
-normalizeWith ops (Object n e)                     = Object n (normalizeObjectLevelWith ops e)
-normalizeWith ops (Procedure n equations)          = Procedure n (mapNormalizeEquationWith ops equations)
-normalizeWith ops (Return e)                       = Return (normalizeWith ops e)
-normalizeWith ops (Rule n args es)                 = Rule n args (mapNormalizeWith ops es)
-normalizeWith ops (Send r e es)                    = Send (normalizeWith ops r) (normalizeWith ops e) (mapNormalizeWith ops es)
-normalizeWith ops (Sequence es)                    = Sequence . sortDeclarationsWith ops .  mapNormalizeWith ops $ es
-normalizeWith ops (LValue n (Lambda vars e))       | convertLambdaVariableIntoFunction ops = SimpleFunction n vars (normalizeWith ops e)
-normalizeWith ops (LValue n (MuObject e))          | convertObjectVariableIntoObject ops = Object n (normalizeObjectLevelWith ops e)
-normalizeWith ops (Variable n e)                   = Variable n (normalizeWith ops e)
-normalizeWith ops (Constant n e)                   = Constant n (normalizeWith ops e)
-normalizeWith ops (Other c (Just e))               = Other c (Just (normalizeWith ops e))
-normalizeWith ops (While e1 e2)                    = While (normalizeWith ops e1) (normalizeWith ops e2)
-normalizeWith _ e = e
+normalizeWith ops (Application (Send r m []) args)      = Send (normalizeWith ops r) (normalizeWith ops m) (mapNormalize ops args)
+normalizeWith ops (LValue n (Lambda vars e))            | convertLambdaVariableIntoFunction ops = SimpleFunction n vars (normalizeWith ops e)
+normalizeWith ops (LValue n (MuObject e))               | convertObjectVariableIntoObject ops = Object n (normalizeObjectLevel ops e)
+normalizeWith ops (Object n e)                          = Object n (normalizeObjectLevel ops e)
+normalizeWith ops (Sequence es)                         = Sequence . sortDeclarationsWith ops .  mapNormalize ops $ es
+--
+normalizeWith _    a@(Assert _ _)                       = a
+normalizeWith ops (For stms e1)                         = For stms (normalizeWith ops e1)
+normalizeWith ops (ForLoop e c i b)                     = ForLoop (normalizeWith ops e) (normalizeWith ops c) (normalizeWith ops i) (normalizeWith ops b)
+normalizeWith ops (Lambda ps e2)                        = Lambda ps (normalizeWith ops e2)
+normalizeWith ops (Match e1 equations)                  = Match (normalizeWith ops e1) (mapNormalizeEquation ops equations)
+normalizeWith ops (Rule n args es)                      = Rule n args (mapNormalize ops es)
+normalizeWith ops (Send r e es)                         = Send (normalizeWith ops r) (normalizeWith ops e) (mapNormalize ops es)
+normalizeWith ops (Switch v cs d)                       = Switch (normalizeWith ops v) (normalizeSwitchCases ops cs) (normalizeWith ops d)
+normalizeWith ops (Try t cs f)                          = Try (normalizeWith ops t) (normalizeTryCases ops cs) (normalizeWith ops f)
+--
+normalizeWith _   (SinglePatternsList ps c)             = c ps
+normalizeWith _   c@(Terminal)                          = c
+normalizeWith ops (ExpressionAndExpressionsList e es c) = c (normalizeWith ops e) (mapNormalize ops es)
+normalizeWith ops (SingleEquationsList eqs c)           = c (mapNormalizeEquation ops eqs)
+normalizeWith ops (SingleExpression e c)                = c (normalizeWith ops e)
+normalizeWith ops (SingleExpressionsList es c)          = c (mapNormalize ops es)
+normalizeWith ops (ThreeExpressions e1 e2 e3 c)         = c (normalizeWith ops e1) (normalizeWith ops e2) (normalizeWith ops e3)
+normalizeWith ops (TwoExpressions e1 e2 c)              = c (normalizeWith ops e1) (normalizeWith ops e2)
 
-mapNormalizeWith ops = map (normalizeWith ops)
-mapNormalizeEquationWith ops = map (normalizeEquationWith ops)
+mapNormalize ops = map (normalizeWith ops)
+mapNormalizeEquation ops = map (normalizeEquation ops)
 
-normalizeObjectLevelWith :: NormalizationOptions -> Expression -> Expression
-normalizeObjectLevelWith ops (Function n eqs)             | convertObjectLevelFunctionIntoMethod ops       = Method n (mapNormalizeEquationWith ops eqs)
-normalizeObjectLevelWith ops (LValue n (Lambda vars e))   | convertObjectLevelLambdaVariableIntoMethod ops = SimpleMethod n vars (normalizeWith ops e)
-normalizeObjectLevelWith ops (LValue n e)                 | convertObjectLevelVariableIntoAttribute ops    = Attribute n (normalizeWith ops e)
-normalizeObjectLevelWith ops (Sequence es)                = Sequence (map (normalizeObjectLevelWith ops) es)
-normalizeObjectLevelWith ops e                            = normalizeWith ops e
+normalizeObjectLevel :: NormalizationOptions -> Expression -> Expression
+normalizeObjectLevel ops (Function n eqs)             | convertObjectLevelFunctionIntoMethod ops       = Method n (mapNormalizeEquation ops eqs)
+normalizeObjectLevel ops (LValue n (Lambda vars e))   | convertObjectLevelLambdaVariableIntoMethod ops = SimpleMethod n vars (normalizeWith ops e)
+normalizeObjectLevel ops (LValue n e)                 | convertObjectLevelVariableIntoAttribute ops    = Attribute n (normalizeWith ops e)
+normalizeObjectLevel ops (Sequence es)                = Sequence (map (normalizeObjectLevel ops) es)
+normalizeObjectLevel ops e                            = normalizeWith ops e
 
-normalizeEquationWith :: NormalizationOptions -> Equation -> Equation
-normalizeEquationWith ops (Equation ps (UnguardedBody e))   = Equation ps (UnguardedBody (normalizeBodyWith ops e))
-normalizeEquationWith ops (Equation ps (GuardedBody b))     = Equation ps (GuardedBody (map (\(c, e) -> (normalizeWith ops c, normalizeBodyWith ops e)) b))
+normalizeEquation :: NormalizationOptions -> Equation -> Equation
+normalizeEquation ops (Equation ps (UnguardedBody e))   = Equation ps (UnguardedBody (normalizeBody ops e))
+normalizeEquation ops (Equation ps (GuardedBody b))     = Equation ps (GuardedBody (map (\(c, e) -> (normalizeWith ops c, normalizeBody ops e)) b))
 
-normalizeBodyWith :: NormalizationOptions -> Expression -> Expression
-normalizeBodyWith ops = normalizeReturnWith ops . normalizeWith ops
+normalizeBody :: NormalizationOptions -> Expression -> Expression
+normalizeBody ops = normalizeReturn ops . normalizeWith ops
 
-normalizeReturnWith :: NormalizationOptions -> Expression -> Expression
-normalizeReturnWith ops e             | not $ insertImplicitReturn ops = e
-normalizeReturnWith _   e             | isImplicitReturn e = Return e
-normalizeReturnWith _   (Sequence es) | Just (i, l) <- unwind es, isImplicitReturn l = Sequence $ i ++ [Return l]
-normalizeReturnWith _   e             = e
+normalizeReturn :: NormalizationOptions -> Expression -> Expression
+normalizeReturn ops e             | not $ insertImplicitReturn ops = e
+normalizeReturn _   e             | isImplicitReturn e = Return e
+normalizeReturn _   (Sequence es) | Just (i, l) <- unwind es, isImplicitReturn l = Sequence $ i ++ [Return l]
+normalizeReturn _   e             = e
+
+normalizeTryCases    ops = map (\(p, e) -> (p, normalizeWith ops e))
+normalizeSwitchCases ops = map (\(e1, e2) -> (normalizeWith ops e1, normalizeWith ops e2))
 
 isImplicitReturn :: Expression -> Bool
 isImplicitReturn (Reference _)         = True

--- a/src/Language/Mulang/Builder.hs
+++ b/src/Language/Mulang/Builder.hs
@@ -1,41 +1,10 @@
-{-# LANGUAGE DeriveGeneric #-}
-
 module Language.Mulang.Builder (
     merge,
     compact,
     compactMap,
-    compactConcatMap,
-    normalize,
-    normalizeWith,
-    defaultNormalizationOptions,
-    NormalizationOptions (..),
-    SequenceSortMode (..)) where
-
-import           GHC.Generics
-
-import Data.List (sort, nub)
-import Data.List.Extra (unwind)
+    compactConcatMap) where
 
 import Language.Mulang.Ast
-import Language.Mulang.Ast.Visitor
-import Language.Mulang.Generator (declarators, declaredIdentifiers)
-import Language.Mulang.Inspector.Literal (isLiteral)
-
-data NormalizationOptions = NormalizationOptions {
-  convertObjectVariableIntoObject :: Bool,
-  convertLambdaVariableIntoFunction :: Bool,
-  convertObjectLevelFunctionIntoMethod :: Bool,
-  convertObjectLevelLambdaVariableIntoMethod :: Bool,
-  convertObjectLevelVariableIntoAttribute :: Bool,
-  sortSequenceDeclarations :: SequenceSortMode,
-  insertImplicitReturn :: Bool
-} deriving (Eq, Show, Read, Generic)
-
-data SequenceSortMode
-  = SortNothing
-  | SortUniqueNonVariables
-  | SortAllNonVarables
-  | SortAll deriving (Eq, Show, Read, Generic)
 
 compactConcatMap :: (a -> [Expression]) -> [a] -> Expression
 compactConcatMap f = compact . concat . map f
@@ -55,103 +24,3 @@ merge (Sequence s1) (Sequence s2)  = Sequence (s1 ++ s2)
 merge (Sequence s1) e2             = Sequence (s1 ++ [e2])
 merge e1            (Sequence s2)  = Sequence (e1 : s2)
 merge e1            e2             = Sequence [e1, e2]
-
-defaultNormalizationOptions :: NormalizationOptions
-defaultNormalizationOptions = NormalizationOptions {
-  convertObjectVariableIntoObject = True,
-  convertLambdaVariableIntoFunction = True,
-  convertObjectLevelFunctionIntoMethod = True,
-  convertObjectLevelLambdaVariableIntoMethod = True,
-  convertObjectLevelVariableIntoAttribute = True,
-  sortSequenceDeclarations = SortAllNonVarables,
-  insertImplicitReturn = False
-}
-
-normalize :: Expression -> Expression
-normalize = normalizeWith defaultNormalizationOptions
-
-normalizeWith :: NormalizationOptions -> Expression -> Expression
-normalizeWith ops (Application (Send r m []) args)      = Send (normalizeWith ops r) (normalizeWith ops m) (mapNormalize ops args)
-normalizeWith ops (LValue n (Lambda vars e))            | convertLambdaVariableIntoFunction ops = SimpleFunction n vars (normalizeWith ops e)
-normalizeWith ops (LValue n (MuObject e))               | convertObjectVariableIntoObject ops = Object n (normalizeObjectLevel ops e)
-normalizeWith ops (Object n e)                          = Object n (normalizeObjectLevel ops e)
-normalizeWith ops (Sequence es)                         = Sequence . sortDeclarationsWith ops .  mapNormalize ops $ es
---
-normalizeWith _    a@(Assert _ _)                       = a
-normalizeWith ops (For stms e1)                         = For stms (normalizeWith ops e1)
-normalizeWith ops (ForLoop e c i b)                     = ForLoop (normalizeWith ops e) (normalizeWith ops c) (normalizeWith ops i) (normalizeWith ops b)
-normalizeWith ops (Lambda ps e2)                        = Lambda ps (normalizeWith ops e2)
-normalizeWith ops (Match e1 equations)                  = Match (normalizeWith ops e1) (mapNormalizeEquation ops equations)
-normalizeWith ops (Rule n args es)                      = Rule n args (mapNormalize ops es)
-normalizeWith ops (Send r e es)                         = Send (normalizeWith ops r) (normalizeWith ops e) (mapNormalize ops es)
-normalizeWith ops (Switch v cs d)                       = Switch (normalizeWith ops v) (normalizeSwitchCases ops cs) (normalizeWith ops d)
-normalizeWith ops (Try t cs f)                          = Try (normalizeWith ops t) (normalizeTryCases ops cs) (normalizeWith ops f)
---
-normalizeWith _   (SinglePatternsList ps c)             = c ps
-normalizeWith _   c@(Terminal)                          = c
-normalizeWith ops (ExpressionAndExpressionsList e es c) = c (normalizeWith ops e) (mapNormalize ops es)
-normalizeWith ops (SingleEquationsList eqs c)           = c (mapNormalizeEquation ops eqs)
-normalizeWith ops (SingleExpression e c)                = c (normalizeWith ops e)
-normalizeWith ops (SingleExpressionsList es c)          = c (mapNormalize ops es)
-normalizeWith ops (ThreeExpressions e1 e2 e3 c)         = c (normalizeWith ops e1) (normalizeWith ops e2) (normalizeWith ops e3)
-normalizeWith ops (TwoExpressions e1 e2 c)              = c (normalizeWith ops e1) (normalizeWith ops e2)
-
-mapNormalize ops = map (normalizeWith ops)
-mapNormalizeEquation ops = map (normalizeEquation ops)
-
-normalizeObjectLevel :: NormalizationOptions -> Expression -> Expression
-normalizeObjectLevel ops (Function n eqs)             | convertObjectLevelFunctionIntoMethod ops       = Method n (mapNormalizeEquation ops eqs)
-normalizeObjectLevel ops (LValue n (Lambda vars e))   | convertObjectLevelLambdaVariableIntoMethod ops = SimpleMethod n vars (normalizeWith ops e)
-normalizeObjectLevel ops (LValue n e)                 | convertObjectLevelVariableIntoAttribute ops    = Attribute n (normalizeWith ops e)
-normalizeObjectLevel ops (Sequence es)                = Sequence (map (normalizeObjectLevel ops) es)
-normalizeObjectLevel ops e                            = normalizeWith ops e
-
-normalizeEquation :: NormalizationOptions -> Equation -> Equation
-normalizeEquation ops (Equation ps (UnguardedBody e))   = Equation ps (UnguardedBody (normalizeBody ops e))
-normalizeEquation ops (Equation ps (GuardedBody b))     = Equation ps (GuardedBody (map (\(c, e) -> (normalizeWith ops c, normalizeBody ops e)) b))
-
-normalizeBody :: NormalizationOptions -> Expression -> Expression
-normalizeBody ops = normalizeReturn ops . normalizeWith ops
-
-normalizeReturn :: NormalizationOptions -> Expression -> Expression
-normalizeReturn ops e             | not $ insertImplicitReturn ops = e
-normalizeReturn _   e             | isImplicitReturn e = Return e
-normalizeReturn _   (Sequence es) | Just (i, l) <- unwind es, isImplicitReturn l = Sequence $ i ++ [Return l]
-normalizeReturn _   e             = e
-
-normalizeTryCases    ops = map (\(p, e) -> (p, normalizeWith ops e))
-normalizeSwitchCases ops = map (\(e1, e2) -> (normalizeWith ops e1, normalizeWith ops e2))
-
-isImplicitReturn :: Expression -> Bool
-isImplicitReturn (Reference _)         = True
-isImplicitReturn (TypeCast _ _)        = True
-isImplicitReturn (FieldReference _ _ ) = True
-isImplicitReturn (Application _ _ )    = True
-isImplicitReturn (Send _ _ _ )         = True
-isImplicitReturn (New _ _ )            = True
-isImplicitReturn (If _ _ _)            = True
-isImplicitReturn e                     = isLiteral e
-
-
-isSafeDeclaration :: Expression -> Bool
-isSafeDeclaration (Attribute _ _) = False
-isSafeDeclaration (LValue _ _)    = False
-isSafeDeclaration (Other _ _)     = False
-isSafeDeclaration e               = isDeclaration e
-
-isDeclaration :: Expression -> Bool
-isDeclaration = not.null.declarators
-
-sortDeclarationsWith :: NormalizationOptions -> [Expression] -> [Expression]
-sortDeclarationsWith ops expressions | shouldSort (sortSequenceDeclarations ops) = sort expressions
-                                     | otherwise                                 = expressions
-  where
-    shouldSort :: SequenceSortMode -> Bool
-    shouldSort SortNothing             = False
-    shouldSort SortUniqueNonVariables  = all isSafeDeclaration expressions && identifiersAreUnique expressions
-    shouldSort SortAllNonVarables      = all isSafeDeclaration expressions
-    shouldSort SortAll                 = all isDeclaration expressions
-
-    identifiersAreUnique = unique . map declaredIdentifiers
-
-    unique xs = nub xs == xs

--- a/src/Language/Mulang/Generator.hs
+++ b/src/Language/Mulang/Generator.hs
@@ -19,6 +19,7 @@ module Language.Mulang.Generator (
   Expression(..)) where
 
 import Language.Mulang.Ast
+import Language.Mulang.Ast.Visitor
 import Language.Mulang.Identifier
 
 import Data.Maybe (mapMaybe)
@@ -68,47 +69,25 @@ expressions :: Generator Expression
 expressions expr = expr : concatMap expressions (subExpressions expr)
   where
     subExpressions :: Generator Expression
-    subExpressions (Arrow e1 e2)           = [e1, e2]
-    subExpressions (Assignment _ e)        = [e]
-    subExpressions (Attribute _ v)         = [v]
-    subExpressions (Call op args)          = op:args
-    subExpressions (Class _ _ v)           = [v]
-    subExpressions (Clause _ _ es)         = es
-    subExpressions (EntryPoint _ e)        = [e]
-    subExpressions (FieldAssignment r _ e) = [r, e]
-    subExpressions (FieldReference r _)    = [r]
-    subExpressions (For stmts a)           = statementsExpressions stmts ++ [a]
-    subExpressions (Forall e1 e2)          = [e1, e2]
-    subExpressions (ForLoop i c p s)       = [i, c, p, s]
-    subExpressions (If a b c)              = [a, b, c]
-    subExpressions (Implement e)           = [e]
-    subExpressions (Include e)             = [e]
-    subExpressions (Interface _ _ v)       = [v]
-    subExpressions (Lambda _ a)            = [a]
-    subExpressions (Match e1 equations)    = e1:equationsExpressions equations
-    subExpressions (MuDict es)             = [es]
-    subExpressions (MuList as)             = as
-    subExpressions (MuObject es)           = [es]
-    subExpressions (MuTuple as)            = as
-    subExpressions (New e es)              = e:es
-    subExpressions (Not e)                 = [e]
-    subExpressions (Object _ v)            = [v]
-    subExpressions (Other _ (Just e))      = [e]
-    subExpressions (Print v)               = [v]
-    subExpressions (Repeat e1 e2)          = [e1, e2]
-    subExpressions (Return v)              = [v]
-    subExpressions (Sequence es)           = es
-    subExpressions (Subroutine _ es)       = equationsExpressions es
-    subExpressions (Switch e1 list _)      = e1 : concatMap (\(x,y) -> [x,y]) list
-    subExpressions (Try t cs f)            = t : map snd cs ++ [f]
-    subExpressions (TypeCast e _)          = [e]
-    subExpressions (Variable _ v)          = [v]
-    subExpressions (Constant _ v)          = [v]
-    subExpressions (While e1 e2)           = [e1, e2]
-    subExpressions (Yield v)               = [v]
-    subExpressions (Break e)               = [e]
-    subExpressions (Continue e)            = [e]
-    subExpressions _                       = []
+    --
+    subExpressions (Assert _ a)                           = [] -- FIXME
+    subExpressions (For stmts a)                          = statementsExpressions stmts ++ [a]
+    subExpressions (ForLoop i c p s)                      = [i, c, p, s]
+    subExpressions (Lambda _ e)                           = [e]
+    subExpressions (Match e eqs)                          = e : equationsExpressions eqs
+    subExpressions (Rule _ _ es)                          = es
+    subExpressions (Send e1 e2 es)                        = e1 : e2 : es
+    subExpressions (Switch e1 list e2)                     = e1 : concatMap (\(x,y) -> [x,y]) list ++ [e2]
+    subExpressions (Try t cs f)                           = t : map snd cs ++ [f]
+    --
+    subExpressions (ExpressionAndExpressionsList e es _)  = e : es
+    subExpressions (SingleEquationsList eqs _)            = equationsExpressions eqs
+    subExpressions (SingleExpression e _)                 = [e]
+    subExpressions (SingleExpressionsList es _)           = es
+    subExpressions (SinglePatternsList _ _)               = []
+    subExpressions (Terminal)                             = []
+    subExpressions (ThreeExpressions e1 e2 e3 _)          = [e1, e2, e3]
+    subExpressions (TwoExpressions e1 e2 _)               = [e1, e2]
 
 
 -- | Returns all the referenced identifiers

--- a/src/Language/Mulang/Parsers/C.hs
+++ b/src/Language/Mulang/Parsers/C.hs
@@ -6,7 +6,8 @@ module Language.Mulang.Parsers.C (c, parseC) where
 import Language.Mulang.Ast
 import qualified Language.Mulang.Ast.Operator as O
 import Language.Mulang.Parsers
-import Language.Mulang.Builder (compactMap, compactConcatMap, normalize)
+import Language.Mulang.Builder (compactMap, compactConcatMap)
+import Language.Mulang.Transform.Normalizer (normalize)
 
 import qualified Language.C.Parser as C
 import Language.C.Syntax

--- a/src/Language/Mulang/Parsers/Haskell.hs
+++ b/src/Language/Mulang/Parsers/Haskell.hs
@@ -3,7 +3,8 @@ module Language.Mulang.Parsers.Haskell (hs, parseHaskell) where
 import Language.Mulang.Ast hiding (Equal, NotEqual)
 import Language.Mulang.Operators.Haskell (haskellTokensTable)
 import Language.Mulang.Operators (parseOperator)
-import Language.Mulang.Builder (compact, normalizeWith, defaultNormalizationOptions, NormalizationOptions(..), SequenceSortMode(..))
+import Language.Mulang.Builder (compact)
+import Language.Mulang.Transform.Normalizer (normalizeWith, defaultNormalizationOptions, NormalizationOptions(..), SequenceSortMode(..))
 import Language.Mulang.Parsers
 
 import Language.Haskell.Syntax

--- a/src/Language/Mulang/Parsers/Java.hs
+++ b/src/Language/Mulang/Parsers/Java.hs
@@ -7,7 +7,8 @@ import Language.Mulang.Ast hiding (Primitive, While, Return, Equal, Lambda, Try,
 import qualified Language.Mulang.Ast as M
 import qualified Language.Mulang.Ast.Operator as O
 import Language.Mulang.Parsers
-import Language.Mulang.Builder (compact, compactMap, compactConcatMap, normalize)
+import Language.Mulang.Builder (compact, compactMap, compactConcatMap)
+import Language.Mulang.Transform.Normalizer (normalize)
 
 import Language.Java.Parser
 import Language.Java.Syntax

--- a/src/Language/Mulang/Parsers/JavaScript.hs
+++ b/src/Language/Mulang/Parsers/JavaScript.hs
@@ -2,7 +2,8 @@ module Language.Mulang.Parsers.JavaScript (js, parseJavaScript) where
 
 import Language.Mulang.Ast hiding (Equal, NotEqual)
 import Language.Mulang.Ast.Operator (Operator (..))
-import Language.Mulang.Builder (compact, compactMap, normalizeWith, defaultNormalizationOptions, NormalizationOptions(..), SequenceSortMode(..))
+import Language.Mulang.Builder (compact, compactMap)
+import Language.Mulang.Transform.Normalizer (normalizeWith, defaultNormalizationOptions, NormalizationOptions(..), SequenceSortMode(..))
 import Language.Mulang.Parsers
 
 import Language.JavaScript.Parser.Parser (parse)

--- a/src/Language/Mulang/Parsers/Prolog.hs
+++ b/src/Language/Mulang/Parsers/Prolog.hs
@@ -7,7 +7,7 @@ import Text.Parsec.Expr
 import Text.Parsec.Numbers
 
 import Language.Mulang.Ast
-import Language.Mulang.Builder
+import Language.Mulang.Builder (compact)
 import Language.Mulang.Parsers
 
 import Data.Maybe (fromMaybe)

--- a/src/Language/Mulang/Parsers/Python.hs
+++ b/src/Language/Mulang/Parsers/Python.hs
@@ -8,7 +8,8 @@ module Language.Mulang.Parsers.Python (
 
 import qualified Language.Mulang.Ast as M
 import qualified Language.Mulang.Ast.Operator as O
-import           Language.Mulang.Builder
+import           Language.Mulang.Builder (compactMap)
+import           Language.Mulang.Transform.Normalizer (normalize)
 import           Language.Mulang.Parsers
 
 import qualified Language.Python.Version3.Parser as Python3

--- a/src/Language/Mulang/Renamer.hs
+++ b/src/Language/Mulang/Renamer.hs
@@ -1,0 +1,248 @@
+module Language.Mulang.Renamer (rename) where
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import           Language.Mulang.Ast
+import           Data.Maybe (catMaybes)
+import           Control.Monad.State
+
+type RenameState a = State ReferencesMap a
+
+data ReferencesMap = ReferencesMap {
+    variables :: Map String String,
+    parameters :: Map String String
+  } deriving Show
+
+emptyReferencesMap :: ReferencesMap
+emptyReferencesMap = ReferencesMap (Map.empty) (Map.empty)
+
+rename :: Expression -> Expression
+rename e = evalState (renameState e) emptyReferencesMap
+
+
+renameState :: Expression -> RenameState Expression
+renameState (Application e es)               = do
+  e' <- renameState e
+  es' <- mapM (renameState) es
+  return $ Application e' es'
+renameState (Arrow e1 e2)                    = do
+  e1' <- renameState e1
+  e2' <- renameState e2
+  return $ Arrow e1' e2'
+renameState (Attribute n e)                  = do
+  e' <- renameState e
+  return $ Attribute n e'
+renameState (Fact n args)                    = do
+  return $ Fact n args
+renameState (For stms e1)                    = do
+  e1' <- renameState e1
+  return $ For stms e1'
+renameState (Forall e1 e2)                   = do
+  e1' <- renameState e1
+  e2' <- renameState e2
+  return $ Forall e1' e2'
+renameState (ForLoop init cond prog stmt)    = do
+  init' <- renameState init
+  cond' <- renameState cond
+  prog' <- renameState prog
+  stmt' <- renameState stmt
+  return $ ForLoop init' cond' prog' stmt'
+renameState (Function n equations)           = do
+  equations' <- renameEquations equations
+  return $ Function n equations'
+renameState (If e1 e2 e3)                    = do
+  e1' <- renameState e1
+  e2' <- renameState e2
+  e3' <- renameState e3
+  return $ If e1' e2' e3'
+renameState (Lambda ps e2)                   = do
+  e2' <- renameState e2
+  return $ Lambda ps e2'
+renameState (Match e1 equations)             = do
+  e1' <- renameState e1
+  equations' <- renameEquations equations
+  return $ Match e1' equations'
+renameState (Method n equations)             = do
+  equations' <- renameEquations equations
+  return $ Method n equations'
+renameState (MuDict e)                       = do
+  e' <- renameState e
+  return $ MuDict e'
+renameState (MuList es)                      = do
+  es' <- mapM (renameState) es
+  return $ MuList es'
+renameState (MuObject e)                     = do
+  e' <- renameState e
+  return $ MuObject e'
+renameState (MuTuple es)                     = do
+  es' <- mapM (renameState) es
+  return $ MuTuple es'
+renameState (Not e)                          = do
+  e' <- renameState e
+  return $ Not e'
+renameState (Object n e)                     = do
+  e' <- renameState e
+  return $ Object n e'
+renameState (Procedure n equations)          = do
+  equations' <- renameEquations equations
+  return $ Procedure n equations'
+renameState (Return e)                       = do
+  e' <- renameState e
+  return $ Return e'
+renameState (Rule n args es)                 = do
+  es' <- mapM (renameState) es
+  return $ Rule n args es'
+renameState (Send r e es)                    = do
+  r' <- renameState r
+  e' <- renameState e
+  es' <- mapM (renameState) es
+  return $ Send r' e' es'
+renameState (Sequence es)                    = do
+  es' <- mapM renameState es
+  return $ Sequence es'
+renameState (Other n (Just e))               = do
+  e' <- renameState e
+  return $ Other n (Just e')
+renameState (While e1 e2)                    = do
+  e1' <- renameState e1
+  e2' <- renameState e2
+  return $ While e1' e2'
+renameState (Yield e)                        = do
+  e' <- renameState e
+  return $ Yield e'
+renameState (TypeCast e t)                   = do
+  e' <- renameState e
+  return $ TypeCast e' t
+renameState (Assignment i e)                 = do
+  e' <- renameState e
+  return $ Assignment i e'
+renameState (Break e)                        = do
+  e' <- renameState e
+  return $ Break e'
+renameState (Class i pi e)                   = do
+  e' <- renameState e
+  return $ Class i pi e'
+renameState (Continue e)                     = do
+  e' <- renameState e
+  return $ Continue e'
+renameState (EntryPoint i e)                 = do
+  e' <- renameState e
+  return $ EntryPoint i e'
+renameState (EqualMethod equations)          = do
+  equations' <- renameEquations equations
+  return $ EqualMethod equations'
+renameState (FieldAssignment e1 i e2)        = do
+  e1' <- renameState e1
+  e2' <- renameState e2
+  return $ FieldAssignment e1' i e2'
+renameState (FieldReference e i)             = do
+  e' <- renameState e
+  return $ FieldReference e' i
+renameState (Findall e1 e2 e3)               = do
+  e1' <- renameState e1
+  e2' <- renameState e2
+  e3' <- renameState e3
+  return $ Findall e1' e2' e3'
+renameState (HashMethod equations)           = do
+  equations' <- renameEquations equations
+  return $ HashMethod equations'
+renameState (Implement e)                    = do
+  e' <- renameState e
+  return $ Implement e'
+renameState (Include e)                      = do
+  e' <- renameState e
+  return $ Include e'
+renameState (Interface i is e)               = do
+  e' <- renameState e
+  return $ Interface i is e'
+renameState (New e es)                       = do
+  e' <- renameState e
+  es' <- mapM renameState es
+  return $ New e' es'
+renameState (PrimitiveMethod op equations)   = do
+  equations' <- renameEquations equations
+  return $ PrimitiveMethod op equations'
+renameState (Print e)                        = do
+  e' <- renameState e
+  return $ Print e'
+renameState (Raise e)                        = do
+  e' <- renameState e
+  return $ Raise e'
+renameState (Repeat e1 e2)                   = do
+  e1' <- renameState e1
+  e2' <- renameState e2
+  return $ Repeat e1' e2'
+renameState (Variable n e)                   = renameVariable n e
+renameState (Reference r)                    = renameReference r
+renameState e                                = return e
+
+renameEquations :: [Equation] -> RenameState [Equation]
+renameEquations equations = do
+  m <- get
+  equations' <- mapM renameEquation equations
+  put m
+  return equations'
+
+renameEquation :: Equation -> RenameState Equation
+renameEquation (Equation ps b) = do
+  ps' <- renameParameters ps
+  b' <- renameEquationBody b
+  return $ Equation ps' b'
+
+renameParameters :: [Pattern] -> RenameState [Pattern]
+renameParameters [p] = do
+  p' <- renameParameter p
+  return [p']
+renameParameters (p:ps) = do
+  p'<- renameParameter p
+  ps' <- renameParameters ps
+  return (p':ps')
+
+renameParameter :: Pattern -> RenameState Pattern
+renameParameter (VariablePattern n) = fmap VariablePattern . createParameter $ n
+renameParameter e                   = return e
+
+renameEquationBody (UnguardedBody e) = fmap UnguardedBody . renameState $ e
+renameEquationBody (GuardedBody es)  = fmap GuardedBody . mapM renameGuard $ es
+  where
+    renameGuard (e1, e2) = do
+      e1' <- renameState e1
+      e2' <- renameState e2
+      return (e1', e2')
+
+renameVariable :: String -> Expression -> RenameState Expression
+renameVariable n e = do
+  n' <- createVariable n
+  e1' <- renameState e
+  return $ Variable n' e1'
+
+renameReference :: String -> RenameState Expression
+renameReference n = do
+    m <- get
+    return . Reference . head . catMaybes $ [lookupVariable n m, lookupParameter n m, Just n]
+
+createVariable :: String -> RenameState String
+createVariable n = do
+    m <- get
+    let n' = makeRef "mulang_var_n" variables m
+    put (m { variables = insertRef n n' variables m })
+    return n'
+
+createParameter :: String -> RenameState String
+createParameter n = do
+    m <- get
+    let n' = makeRef "mulang_param_n" parameters m
+    put (m { parameters = insertRef n n' parameters m })
+    return n'
+
+makeRef :: String -> (ReferencesMap -> Map String String) -> ReferencesMap -> String
+makeRef kind f = (kind++) . show . length . f
+
+insertRef :: String -> String -> (ReferencesMap -> Map String String) -> ReferencesMap -> Map String String
+insertRef n n' f = Map.insert n n' . f
+
+lookupVariable :: String -> ReferencesMap -> (Maybe String)
+lookupVariable n m = Map.lookup n (variables m)
+
+lookupParameter :: String -> ReferencesMap -> (Maybe String)
+lookupParameter n m = Map.lookup n (parameters m)

--- a/src/Language/Mulang/Transform/Normalizer.hs
+++ b/src/Language/Mulang/Transform/Normalizer.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module Language.Mulang.Transform.Normalizer (
+    normalize,
+    normalizeWith,
+    defaultNormalizationOptions,
+    NormalizationOptions (..),
+    SequenceSortMode (..)) where
+
+import           GHC.Generics
+
+import Data.List (sort, nub)
+import Data.List.Extra (unwind)
+
+import Language.Mulang.Ast
+import Language.Mulang.Ast.Visitor
+import Language.Mulang.Generator (declarators, declaredIdentifiers)
+import Language.Mulang.Inspector.Literal (isLiteral)
+
+data NormalizationOptions = NormalizationOptions {
+  convertObjectVariableIntoObject :: Bool,
+  convertLambdaVariableIntoFunction :: Bool,
+  convertObjectLevelFunctionIntoMethod :: Bool,
+  convertObjectLevelLambdaVariableIntoMethod :: Bool,
+  convertObjectLevelVariableIntoAttribute :: Bool,
+  sortSequenceDeclarations :: SequenceSortMode,
+  insertImplicitReturn :: Bool
+} deriving (Eq, Show, Read, Generic)
+
+data SequenceSortMode
+  = SortNothing
+  | SortUniqueNonVariables
+  | SortAllNonVarables
+  | SortAll deriving (Eq, Show, Read, Generic)
+
+defaultNormalizationOptions :: NormalizationOptions
+defaultNormalizationOptions = NormalizationOptions {
+  convertObjectVariableIntoObject = True,
+  convertLambdaVariableIntoFunction = True,
+  convertObjectLevelFunctionIntoMethod = True,
+  convertObjectLevelLambdaVariableIntoMethod = True,
+  convertObjectLevelVariableIntoAttribute = True,
+  sortSequenceDeclarations = SortAllNonVarables,
+  insertImplicitReturn = False
+}
+
+normalize :: Expression -> Expression
+normalize = normalizeWith defaultNormalizationOptions
+
+normalizeWith :: NormalizationOptions -> Expression -> Expression
+normalizeWith ops (Application (Send r m []) args)      = Send (normalizeWith ops r) (normalizeWith ops m) (mapNormalize ops args)
+normalizeWith ops (LValue n (Lambda vars e))            | convertLambdaVariableIntoFunction ops = SimpleFunction n vars (normalizeWith ops e)
+normalizeWith ops (LValue n (MuObject e))               | convertObjectVariableIntoObject ops = Object n (normalizeObjectLevel ops e)
+normalizeWith ops (Object n e)                          = Object n (normalizeObjectLevel ops e)
+normalizeWith ops (Sequence es)                         = Sequence . sortDeclarationsWith ops .  mapNormalize ops $ es
+--
+normalizeWith _    a@(Assert _ _)                       = a
+normalizeWith ops (For stms e1)                         = For stms (normalizeWith ops e1)
+normalizeWith ops (ForLoop e c i b)                     = ForLoop (normalizeWith ops e) (normalizeWith ops c) (normalizeWith ops i) (normalizeWith ops b)
+normalizeWith ops (Lambda ps e2)                        = Lambda ps (normalizeWith ops e2)
+normalizeWith ops (Match e1 equations)                  = Match (normalizeWith ops e1) (mapNormalizeEquation ops equations)
+normalizeWith ops (Rule n args es)                      = Rule n args (mapNormalize ops es)
+normalizeWith ops (Send r e es)                         = Send (normalizeWith ops r) (normalizeWith ops e) (mapNormalize ops es)
+normalizeWith ops (Switch v cs d)                       = Switch (normalizeWith ops v) (normalizeSwitchCases ops cs) (normalizeWith ops d)
+normalizeWith ops (Try t cs f)                          = Try (normalizeWith ops t) (normalizeTryCases ops cs) (normalizeWith ops f)
+--
+normalizeWith _   (SinglePatternsList ps c)             = c ps
+normalizeWith _   c@(Terminal)                          = c
+normalizeWith ops (ExpressionAndExpressionsList e es c) = c (normalizeWith ops e) (mapNormalize ops es)
+normalizeWith ops (SingleEquationsList eqs c)           = c (mapNormalizeEquation ops eqs)
+normalizeWith ops (SingleExpression e c)                = c (normalizeWith ops e)
+normalizeWith ops (SingleExpressionsList es c)          = c (mapNormalize ops es)
+normalizeWith ops (ThreeExpressions e1 e2 e3 c)         = c (normalizeWith ops e1) (normalizeWith ops e2) (normalizeWith ops e3)
+normalizeWith ops (TwoExpressions e1 e2 c)              = c (normalizeWith ops e1) (normalizeWith ops e2)
+
+mapNormalize ops = map (normalizeWith ops)
+mapNormalizeEquation ops = map (normalizeEquation ops)
+
+normalizeObjectLevel :: NormalizationOptions -> Expression -> Expression
+normalizeObjectLevel ops (Function n eqs)             | convertObjectLevelFunctionIntoMethod ops       = Method n (mapNormalizeEquation ops eqs)
+normalizeObjectLevel ops (LValue n (Lambda vars e))   | convertObjectLevelLambdaVariableIntoMethod ops = SimpleMethod n vars (normalizeWith ops e)
+normalizeObjectLevel ops (LValue n e)                 | convertObjectLevelVariableIntoAttribute ops    = Attribute n (normalizeWith ops e)
+normalizeObjectLevel ops (Sequence es)                = Sequence (map (normalizeObjectLevel ops) es)
+normalizeObjectLevel ops e                            = normalizeWith ops e
+
+normalizeEquation :: NormalizationOptions -> Equation -> Equation
+normalizeEquation ops (Equation ps (UnguardedBody e))   = Equation ps (UnguardedBody (normalizeBody ops e))
+normalizeEquation ops (Equation ps (GuardedBody b))     = Equation ps (GuardedBody (map (\(c, e) -> (normalizeWith ops c, normalizeBody ops e)) b))
+
+normalizeBody :: NormalizationOptions -> Expression -> Expression
+normalizeBody ops = normalizeReturn ops . normalizeWith ops
+
+normalizeReturn :: NormalizationOptions -> Expression -> Expression
+normalizeReturn ops e             | not $ insertImplicitReturn ops = e
+normalizeReturn _   e             | isImplicitReturn e = Return e
+normalizeReturn _   (Sequence es) | Just (i, l) <- unwind es, isImplicitReturn l = Sequence $ i ++ [Return l]
+normalizeReturn _   e             = e
+
+normalizeTryCases    ops = map (\(p, e) -> (p, normalizeWith ops e))
+normalizeSwitchCases ops = map (\(e1, e2) -> (normalizeWith ops e1, normalizeWith ops e2))
+
+isImplicitReturn :: Expression -> Bool
+isImplicitReturn (Reference _)         = True
+isImplicitReturn (TypeCast _ _)        = True
+isImplicitReturn (FieldReference _ _ ) = True
+isImplicitReturn (Application _ _ )    = True
+isImplicitReturn (Send _ _ _ )         = True
+isImplicitReturn (New _ _ )            = True
+isImplicitReturn (If _ _ _)            = True
+isImplicitReturn e                     = isLiteral e
+
+
+isSafeDeclaration :: Expression -> Bool
+isSafeDeclaration (Attribute _ _) = False
+isSafeDeclaration (LValue _ _)    = False
+isSafeDeclaration (Other _ _)     = False
+isSafeDeclaration e               = isDeclaration e
+
+isDeclaration :: Expression -> Bool
+isDeclaration = not.null.declarators
+
+sortDeclarationsWith :: NormalizationOptions -> [Expression] -> [Expression]
+sortDeclarationsWith ops expressions | shouldSort (sortSequenceDeclarations ops) = sort expressions
+                                     | otherwise                                 = expressions
+  where
+    shouldSort :: SequenceSortMode -> Bool
+    shouldSort SortNothing             = False
+    shouldSort SortUniqueNonVariables  = all isSafeDeclaration expressions && identifiersAreUnique expressions
+    shouldSort SortAllNonVarables      = all isSafeDeclaration expressions
+    shouldSort SortAll                 = all isDeclaration expressions
+
+    identifiersAreUnique = unique . map declaredIdentifiers
+
+    unique xs = nub xs == xs

--- a/src/Language/Mulang/Transform/Renamer.hs
+++ b/src/Language/Mulang/Transform/Renamer.hs
@@ -1,4 +1,4 @@
-module Language.Mulang.Renamer (rename) where
+module Language.Mulang.Transform.Renamer (rename) where
 
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map

--- a/src/Language/Mulang/Transform/Renamer.hs
+++ b/src/Language/Mulang/Transform/Renamer.hs
@@ -60,18 +60,9 @@ renameEquations equations = do
 
 renameEquation :: Equation -> RenameState Equation
 renameEquation (Equation ps b) = do
-  ps' <- renameParameters ps
+  ps' <- mapM renameParameter ps
   b' <- renameEquationBody b
   return $ Equation ps' b'
-
-renameParameters :: [Pattern] -> RenameState [Pattern]
-renameParameters [p] = do
-  p' <- renameParameter p
-  return [p']
-renameParameters (p:ps) = do
-  p'<- renameParameter p
-  ps' <- renameParameters ps
-  return (p':ps')
 
 renameParameter :: Pattern -> RenameState Pattern
 renameParameter (VariablePattern n) = fmap VariablePattern . createParameter $ n


### PR DESCRIPTION
# :dart: Goal 

To allow mulang to generate more abstract representations of code structure where names are less important

# :memo: Details

This PR just introduced the `Renamer`  module and refactors the `Normalizer` to generalize the concept of transforms, but does not actually use the rename code. It will be wired in coming-soon PRs. 

# :warning: Warnings

Rebase after #301 