### PR TITLE
Fix js decimal parsing error

### DIFF
--- a/spec/JavaScriptSpec.hs
+++ b/spec/JavaScriptSpec.hs
@@ -30,6 +30,12 @@ spec = do
     it "simple string assignment" $ do
       js "let x = 'hello'" `shouldBe` hs "x = \"hello\""
 
+    it "number parsing" $ do
+      js "1" `shouldBe` (MuNumber 1)
+      js "1.0" `shouldBe` (MuNumber 1)
+      js "1." `shouldBe` (MuNumber 1.0)
+      js ".1" `shouldBe` (MuNumber 0.1)
+
     it "string parsing" $ do
       js "var x = \"hello\"" `shouldBe` js "var x = 'hello'"
       js "let x = \"hello\"" `shouldBe` js "let x = 'hello'"

--- a/src/Language/Mulang/Parsers/JavaScript.hs
+++ b/src/Language/Mulang/Parsers/JavaScript.hs
@@ -139,7 +139,7 @@ containsReturn _             = False
 muJSExpression:: JSExpression -> Expression
 muJSExpression (JSIdentifier _ "undefined")                         = None
 muJSExpression (JSIdentifier _ name)                                = Reference name
-muJSExpression (JSDecimal _ val)                                    = MuNumber (read val)
+muJSExpression (JSDecimal _ val)                                    = muDecimal val
 muJSExpression (JSLiteral _ "null")                                 = MuNil
 muJSExpression (JSLiteral _ "true")                                 = MuTrue
 muJSExpression (JSLiteral _ "false")                                = MuFalse
@@ -276,3 +276,10 @@ muJSArrowParameterList :: JSArrowParameterList -> [Pattern]
 muJSArrowParameterList (JSUnparenthesizedArrowParameter ident)        = [muIdentPattern ident]
 muJSArrowParameterList (JSParenthesizedArrowParameterList _ params _) = muJSPatternList params
 
+muDecimal s@('.':_) = muDecimal ('0':s)
+muDecimal str       = decode (reads str)
+  where
+    decode [(n, "")]  = MuNumber n
+    decode [(n, ".")] = MuNumber n
+    decode [(n, s)]   = other ("JSDecimal:" ++ s) (MuNumber n)
+    decode _          = debug ("JSDecimal:" ++ str)


### PR DESCRIPTION
# :dart: Goal

To fix a long standing parsing issue with JS code related to decimal numbers format, that was not only not producing a valid AST, but also was breaking the mulang tool itself because of not having a proper error handling code. In fact, it was responsible for all `Prelude.read no parse` errors. 

# :warning: Warnings

Rebase after #301 