### PR TITLE
Feature batch mode

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,7 +2,7 @@
 
 module Main where
 
-import Language.Mulang.Analyzer (analyse)
+import Language.Mulang.Analyzer (analyse, analyseMany)
 import Language.Mulang.Analyzer.Analysis.Json ()
 import Data.Aeson (eitherDecode, encode)
 import System.Environment (getArgs)
@@ -32,24 +32,33 @@ analyseJson = fmap encode . analyse . decode . encodeUtf8 . T.pack
   where
     decode = orFail . eitherDecode
 
+analyseJsons :: String -> IO ByteString
+analyseJsons = fmap encode . analyseMany . decode . encodeUtf8 . T.pack
+   where
+      decode = orFail . eitherDecode
+
 main :: IO ()
 main = do
-  argsBody <- fmap parseArgs $ getArgs
   streamBody <- getContents
-  let body = if argsBody == "-s" then streamBody else argsBody
-  result <- analyseJson body
+  args <- getArgs
+  result <- run args streamBody
   LBS.putStrLn result
 
   where
-    parseArgs :: [String] -> String
-    parseArgs [jsonBody] = jsonBody
-    parseArgs _          = error (intercalate "\n" [prettyVersion, usage])
+    run :: [String] -> String ->  IO ByteString
+    run ["-s"] body = analyseJson body
+    run ["-S"] body = analyseJsons body
+    run [body] _    = analyseJson body
+    run  _     _    = error (intercalate "\n" [prettyVersion, usage])
 
     usage = unpack [text|
         Wrong usage.
 
          #read from STDIN
          $ mulang -s
+
+         #read from STDIN a list of analysis
+         $ mulang -S
 
          #read from argument
          $ mulang '{

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -57,7 +57,7 @@ main = do
          #read from STDIN
          $ mulang -s
 
-         #read from STDIN a list of analysis
+         #read from STDIN a list of analyses
          $ mulang -S
 
          #read from argument

--- a/gem/lib/mulang.rb
+++ b/gem/lib/mulang.rb
@@ -10,7 +10,9 @@ module Mulang
     File.join(__dir__, '..', 'bin', 'mulang')
   end
   def self.analyse(analysis)
-    Open3.popen2(bin_path, '-s') do |input, output, _thread|
+    mode = analysis.is_a?(Array) ? '-S' : '-s'
+
+    Open3.popen2(bin_path, mode) do |input, output, _thread|
       input.puts analysis.to_json
       input.close
       JSON.parse output.read

--- a/gem/lib/mulang/code.rb
+++ b/gem/lib/mulang/code.rb
@@ -9,6 +9,10 @@ module Mulang
       @language.ast @content
     end
 
+    def ast_analysis
+      @language.ast_analysis @content
+    end
+
     def sample
       @language.sample @content
     end
@@ -49,6 +53,14 @@ module Mulang
 
     def self.ast(ast)
       new Mulang::Language::External.new, ast
+    end
+
+    def self.analyse_many(codes, spec)
+      Mulang.analyse codes.map { |it| it.analysis(spec)  }
+    end
+
+    def self.ast_many(codes)
+      Mulang.analyse codes.map { |it| it.ast_analysis  }
     end
 
     private

--- a/gem/lib/mulang/code.rb
+++ b/gem/lib/mulang/code.rb
@@ -61,7 +61,7 @@ module Mulang
     end
 
     def self.ast_many(codes)
-      Mulang.analyse codes.map { |it| it.ast_analysis  }
+      Mulang.analyse(codes.map { |it| it.ast_analysis  }).map { |it| it['intermediateLanguage'] }
     end
 
     private

--- a/gem/lib/mulang/code.rb
+++ b/gem/lib/mulang/code.rb
@@ -1,5 +1,6 @@
 module Mulang
   class Code
+    attr_accessor :language, :content
     def initialize(language, content)
       @language = language
       @content  = content

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -138,4 +138,12 @@ describe Mulang::Code do
 
     end
   end
+
+  context 'when batch mode is used' do
+    let(:codes) { 3.times.map { |it| Mulang::Code.native("JavaScript", "let x = #{it}") } }
+
+    it "results are functionally equivalent to standard mode" do
+      expect(Mulang::Code.ast_many codes).to eq codes.map(&:ast)
+    end
+  end
 end

--- a/src/Language/Mulang/Analyzer.hs
+++ b/src/Language/Mulang/Analyzer.hs
@@ -1,5 +1,6 @@
 module Language.Mulang.Analyzer (
   analyse,
+  analyseMany,
   module Language.Mulang.Analyzer.Analysis) where
 
 import Language.Mulang
@@ -18,6 +19,9 @@ import Data.Maybe (fromMaybe)
 --
 -- Analysis running
 --
+
+analyseMany :: [Analysis] -> IO [AnalysisResult]
+analyseMany = mapM analyse
 
 analyse, analyse' :: Analysis -> IO AnalysisResult
 analyse = analyse' . autocorrect


### PR DESCRIPTION
# :dart:  Goal

To allow batch processing of many  `Analysis` objects, which is a huge performance boost when using Mulang from ruby bindings.  

# :memo: Details

In my machine, this PR made mulang run 20 times faster in batch mode with 5K code snippets: 

```ruby
codes = 5000.times.map { |it| Mulang::Code.native("JavaScript", "let x = #{it}") }

Benchmark.measure { codes.map(&:ast) }
=> #<Benchmark::Tms:0x0000559f26f40888
 @cstime=2.2249019999999997,
 @cutime=6.524682,
 @label="",
 @real=8.298607618999085,
 @stime=0.47271799999999997,
 @total=9.968713,
 @utime=0.7464109999999999>

Benchmark.measure { Mulang::Code.ast_many codes }
=> #<Benchmark::Tms:0x0000559f27d208b8
 @cstime=0.01631700000000036,
 @cutime=0.26108499999999957,
 @label="",
 @real=0.49491714800024056,
 @stime=0.004264999999999963,
 @total=0.5073949999999998,
 @utime=0.22572799999999993>

```