### PR TITLE
Feature ast serialization

### DIFF
--- a/gem/lib/mulang.rb
+++ b/gem/lib/mulang.rb
@@ -9,13 +9,27 @@ module Mulang
   def self.bin_path
     File.join(__dir__, '..', 'bin', 'mulang')
   end
-  def self.analyse(analysis)
-    mode = analysis.is_a?(Array) ? '-S' : '-s'
+  def self.analyse(analysis, **options)
+    serialization = options[:serialization]
+    many = analysis.is_a?(Array)
+    mode = many || serialization ? encode_serialization(serialization) : '-s'
 
     Open3.popen2(bin_path, mode) do |input, output, _thread|
-      input.puts analysis.to_json
+      input.puts (!many && serialization ? [analysis] : analysis).to_json
       input.close
-      JSON.parse output.read
+      result = JSON.parse output.read
+      !many && serialization ? result[0] : result
+    end
+  end
+
+  private
+
+  def self.encode_serialization(option)
+    case option
+    when nil then '-S'
+    when :bracket then '-B'
+    when :brace then '-C'
+    else raise "Unsupported serialization #{option}"
     end
   end
 end

--- a/gem/lib/mulang/code.rb
+++ b/gem/lib/mulang/code.rb
@@ -30,8 +30,8 @@ module Mulang
       { sample: sample, spec: spec }
     end
 
-    def analyse(spec)
-      Mulang.analyse analysis(spec)
+    def analyse(spec, **options)
+      Mulang.analyse analysis(spec), **options
     end
 
     def expect(binding='*', inspection)
@@ -60,22 +60,22 @@ module Mulang
       new Mulang::Language::External.new(&tool), content
     end
 
-    def self.analyse_many(codes, spec)
-      run_many(codes) { |it| it.analysis(spec)  }
+    def self.analyse_many(codes, spec, **options)
+      run_many(codes, **options) { |it| it.analysis(spec)  }
     end
 
     def self.ast_many(codes, **options)
-      run_many(codes, key: 'outputAst') { |it| it.ast_analysis(**options) }
+      run_many(codes, key: 'outputAst', **options) { |it| it.ast_analysis(**options) }
     end
 
     def self.transformed_asts_many(codes, operations, **options)
-      run_many(codes, key: 'transformedAsts') { |it| it.transformed_asts_analysis(operations, **options) }
+      run_many(codes, key: 'transformedAsts', **options) { |it| it.transformed_asts_analysis(operations, **options) }
     end
 
     private
 
-    def self.run_many(codes, key: nil)
-      result = Mulang.analyse(codes.map { |it| yield it })
+    def self.run_many(codes, key: nil, **options)
+      result = Mulang.analyse(codes.map { |it| yield it }, **options)
       key ? result.map { |it| it[key] } : result
     end
 

--- a/gem/lib/mulang/language.rb
+++ b/gem/lib/mulang/language.rb
@@ -1,7 +1,7 @@
 module Mulang::Language
   class Base
     def transformed_asts(content, operations, **options)
-      Mulang.analyse(transformed_asts_analysis(content, operations, **options))['transformedAsts'] rescue nil
+      Mulang.analyse(transformed_asts_analysis(content, operations, **options), **options)['transformedAsts'] rescue nil
     end
 
     def transformed_asts_analysis(content, operations, **options)
@@ -12,9 +12,13 @@ module Mulang::Language
           smellsSet: { tag: 'NoSmells' },
           includeOutputAst: false,
           transformationSpecs: operations,
-          normalizationOptions: options.presence
+          normalizationOptions: normalization_options(options)
         }.compact
       }
+    end
+
+    def normalization_options(**options)
+      options.except(:serialization).presence
     end
   end
 
@@ -24,7 +28,7 @@ module Mulang::Language
     end
 
     def ast(content, **options)
-      Mulang.analyse(ast_analysis(content, **options))['outputAst'] rescue nil
+      Mulang.analyse(ast_analysis(content, **options), **options)['outputAst'] rescue nil
     end
 
     def ast_analysis(content, **options)
@@ -34,7 +38,7 @@ module Mulang::Language
           expectations: [],
           smellsSet: { tag: 'NoSmells' },
           includeOutputAst: true,
-          normalizationOptions: options.presence
+          normalizationOptions: normalization_options(options)
         }.compact
       }
     end

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -5,6 +5,7 @@ describe Mulang::Code do
     let(:code) { Mulang::Code.native('JavaScript', 'let x = 1') }
 
     it { expect(code.ast).to eq "tag"=>"Variable", "contents"=>["x", {"tag"=>"MuNumber", "contents"=>1}] }
+    it { expect(code.ast serialization: :bracket).to eq "[Variable[x][MuNumber[1.0]]]" }
     it { expect(code.analyse expectations: [], smellsSet: { tag: 'NoSmells' }). to eq 'tag'=>'AnalysisCompleted',
                                                                                       'outputAst'=>nil,
                                                                                       'transformedAsts' => nil,
@@ -64,6 +65,16 @@ describe Mulang::Code do
                         {"contents"=>{"contents"=>"mulang_var_n0", "tag"=>"Reference"},
                          "tag"=>"Print"}],
                       "tag"=>"Sequence"}]
+      end
+
+      it "can produce multiple transformed asts with serialization options" do
+        expect(code.transformed_asts [
+                      [{tag: :Normalize, contents: { convertObjectIntoDict: true }}],
+                      [{tag: :Crop, contents: "IsVariable:y"}, {tag: :RenameVariables}]
+                    ], convertObjectVariableIntoObject: false, serialization: :brace).to eq [
+                      "{Sequence{Variable{x}{MuDict{None}}}{Variable{y}{MuNumber{2.0}}}{Print{Reference{x}}}}",
+                      "{Sequence{Variable{mulang_var_n0}{MuObject{None}}}{Print{Reference{mulang_var_n0}}}}"
+                    ]
       end
     end
 

--- a/mulang.cabal
+++ b/mulang.cabal
@@ -108,6 +108,7 @@ library
     Language.Mulang.Edl.Expectation
     Language.Mulang.Edl.Lexer
     Language.Mulang.Edl.Parser
+    Language.Mulang.Serializer
     Language.Mulang.Interpreter
     Language.Mulang.Interpreter.Internals
     Language.Mulang.Interpreter.Runner

--- a/spec/SerializerSpec.hs
+++ b/spec/SerializerSpec.hs
@@ -1,18 +1,20 @@
 module SerializerSpec (spec) where
 
 import           Test.Hspec
-import           Language.Mulang.Ast
-import           Language.Mulang.Serializer (serialize)
+import           Language.Mulang.Serializer (brace, bracket)
 import           Language.Mulang.Parsers.JavaScript (js)
 
 spec :: Spec
 spec = do
   describe "Serializer" $ do
     it "Serializes non empty asts" $ do
-      (serialize (js "if (c) 1 else 2")) `shouldBe` "{If{Reference{c}}{MuNumber{1.0}}{MuNumber{2.0}}}"
-      (serialize (js "({x: true, z: null})")) `shouldBe` "{MuObject{Sequence{Variable{x}{MuBool{True}}}{Variable{z}{MuNil}}}}"
-      (serialize (js "function f(y) {return x + y}")) `shouldBe` "{Function{f}{Equation{VariablePattern{y}}{UnguardedBody{Return{Application{Primitive{Plus}}{Reference{x}}{Reference{y}}}}}}}"
-      (serialize (js "function f(y) {return y * x}")) `shouldBe` "{Function{f}{Equation{VariablePattern{y}}{UnguardedBody{Return{Application{Primitive{Multiply}}{Reference{y}}{Reference{x}}}}}}}"
+      (brace (js "if (c) 1 else 2")) `shouldBe` "{If{Reference{c}}{MuNumber{1.0}}{MuNumber{2.0}}}"
+      (brace (js "({x: true, z: null})")) `shouldBe` "{MuObject{Sequence{Variable{x}{MuBool{True}}}{Variable{z}{MuNil}}}}"
+      (brace (js "function f(y) {return x + y}")) `shouldBe` "{Function{f}{Equation{VariablePattern{y}}{UnguardedBody{Return{Application{Primitive{Plus}}{Reference{x}}{Reference{y}}}}}}}"
+      (brace (js "function f(y) {return y * x}")) `shouldBe` "{Function{f}{Equation{VariablePattern{y}}{UnguardedBody{Return{Application{Primitive{Multiply}}{Reference{y}}{Reference{x}}}}}}}"
+
+    it "Serializes non empty asts with brackets" $ do
+      (bracket (js "if (c) 1 else 2")) `shouldBe` "[If[Reference[c]][MuNumber[1.0]][MuNumber[2.0]]]"
 
     it "Serializes empty asts" $ do
-      (serialize (js "")) `shouldBe` "{None}"
+      (brace (js "")) `shouldBe` "{None}"

--- a/spec/SerializerSpec.hs
+++ b/spec/SerializerSpec.hs
@@ -1,0 +1,18 @@
+module SerializerSpec (spec) where
+
+import           Test.Hspec
+import           Language.Mulang.Ast
+import           Language.Mulang.Serializer (serialize)
+import           Language.Mulang.Parsers.JavaScript (js)
+
+spec :: Spec
+spec = do
+  describe "Serializer" $ do
+    it "Serializes non empty asts" $ do
+      (serialize (js "if (c) 1 else 2")) `shouldBe` "{If{Reference{c}}{MuNumber{1.0}}{MuNumber{2.0}}}"
+      (serialize (js "({x: true, z: null})")) `shouldBe` "{MuObject{Sequence{Variable{x}{MuBool{True}}}{Variable{z}{MuNil}}}}"
+      (serialize (js "function f(y) {return x + y}")) `shouldBe` "{Function{f}{Equation{VariablePattern{y}}{UnguardedBody{Return{Application{Primitive{Plus}}{Reference{x}}{Reference{y}}}}}}}"
+      (serialize (js "function f(y) {return y * x}")) `shouldBe` "{Function{f}{Equation{VariablePattern{y}}{UnguardedBody{Return{Application{Primitive{Multiply}}{Reference{y}}{Reference{x}}}}}}}"
+
+    it "Serializes empty asts" $ do
+      (serialize (js "")) `shouldBe` "{None}"

--- a/src/Language/Mulang/Analyzer/Analysis.hs
+++ b/src/Language/Mulang/Analyzer/Analysis.hs
@@ -42,6 +42,7 @@ module Language.Mulang.Analyzer.Analysis (
   QueryResult,
 
   AnalysisResult(..),
+  GenericAnalysisResult(..),
   ExpectationResult(..)) where
 
 import GHC.Generics
@@ -163,18 +164,18 @@ data Language
 
 type QueryResult = (Query, ExpectationResult)
 
+type AnalysisResult = GenericAnalysisResult Expression
 --
 -- Analysis Output structures
 --
-
-data AnalysisResult
+data GenericAnalysisResult a
   = AnalysisCompleted {
       expectationResults :: [ExpectationResult],
       smells :: [Expectation],
       signatures :: [Code],
       testResults :: [TestResult],
-      outputAst :: Maybe Expression,
-      transformedAsts :: Maybe [Expression] }
+      outputAst :: Maybe a,
+      transformedAsts :: Maybe [a] }
   | AnalysisFailed { reason :: String } deriving (Show, Eq, Generic)
 
 data ExpectationResult = ExpectationResult {

--- a/src/Language/Mulang/Analyzer/Analysis/Json.hs
+++ b/src/Language/Mulang/Analyzer/Analysis/Json.hs
@@ -51,7 +51,7 @@ instance FromJSON TransformationOperation
 instance FromJSON InterpreterOptions
 instance FromJSON Operator
 
-instance ToJSON AnalysisResult
+instance ToJSON a => ToJSON (GenericAnalysisResult a)
 instance ToJSON ExpectationResult
 
 instance ToJSON Expectation

--- a/src/Language/Mulang/Serializer.hs
+++ b/src/Language/Mulang/Serializer.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DefaultSignatures, TypeOperators, FlexibleContexts, FlexibleInstances #-}
+
+module Language.Mulang.Serializer (serialize) where
+
+import GHC.Generics
+
+import Language.Mulang.Ast
+import Language.Mulang.Ast.Operator
+
+serialize :: Bracket a => a -> String
+serialize = bracketize
+
+instance Bracket Pattern
+instance Bracket Expression
+instance Bracket Equation
+instance Bracket EquationBody
+instance Bracket Statement
+instance Bracket Operator
+instance Bracket Type
+instance Bracket Assertion
+
+instance (Bracket a, Bracket b) => Bracket (a, b) where
+  bracketize (a, b) = "{," ++ bracketize a ++ bracketize b ++"}"
+
+instance Bracket a => Bracket (Maybe a) where
+  bracketize Nothing = "{}"
+  bracketize (Just a) = "{" ++ bracketize a ++ "}"
+
+instance Bracket a => Bracket [a] where
+  bracketize = concatMap bracketize
+
+instance {-# OVERLAPPING #-} Bracket String where
+  bracketize s = "{" ++ s ++ "}"
+
+instance Bracket Double where
+  bracketize = showBracketize
+
+instance Bracket Bool where
+  bracketize = showBracketize
+
+instance Bracket Char where
+  bracketize = showBracketize
+
+showBracketize :: Show a => a -> String
+showBracketize = bracketize . show
+
+class Bracket' f where
+  bracketize' :: f p -> String
+
+instance Bracket' V1 where
+  bracketize' _ = ""
+
+instance Bracket' U1 where
+  bracketize' _ = ""
+
+instance Bracket c => Bracket' (K1 i c) where
+  bracketize' (K1 x) = bracketize x
+
+instance (Bracket' f, Constructor c) => Bracket' (M1 C c f) where
+  bracketize' c@(M1 x) = "{" ++ (conName c) ++ bracketize' x ++ "}"
+
+instance (Bracket' f) => Bracket' (M1 S s f) where
+  bracketize' (M1 x) = bracketize' x
+
+instance (Bracket' f) => Bracket' (M1 D d f) where
+  bracketize' (M1 x) = bracketize' x
+
+instance (Bracket' a, Bracket' b) => Bracket' (a :+: b) where
+  bracketize' (L1 x) = bracketize' x
+  bracketize' (R1 x) = bracketize' x
+
+instance (Bracket' a, Bracket' b) => Bracket' (a :*: b) where
+  bracketize' (a :*: b) = bracketize' a ++ bracketize' b
+
+class Bracket a where
+  bracketize :: a -> String
+  default bracketize :: (Generic a, Bracket' (Rep a)) => a -> String
+  bracketize = bracketize' . from


### PR DESCRIPTION
# :dart: Goal

To allow alternative serializations of AST, in modes accepted by other tools from the Ruby interface: 

* [labelled bracket notation](http://www.glottopedia.org/index.php/Labeled_bracketing)
* labelled brace notation

The first one - which is quite standard - can be used in tools like [this](http://www.tycho.iel.unicamp.br/phpsyntaxtree/) or [this](http://mshang.ca/syntree/) to render a tree like this... 

![image](https://user-images.githubusercontent.com/677436/104251053-ac029f00-544d-11eb-8b89-a6623d9f64f4.png)

..or this: 

![image](https://user-images.githubusercontent.com/677436/104251190-ebc98680-544d-11eb-9045-0ee37e9b20f1.png)

The latter - which seems to be pretty rare - can be used with [this tool](https://pypi.org/project/apted/)

# :soon: Future work

In the future, we may add formats like [Newick](https://en.wikipedia.org/wiki/Newick_format) or S-expression too.  

# :test_tube: Test instructions

You can activate serialization using the `serialization` argument from Ruby interface:


```ruby
> code = Mulang::Code.native('JavaScript', 'let x = 1; console.log(2 * x)')
> code.ast
=> {"tag"=>"Sequence",
 "contents"=>
  [{"tag"=>"Variable", "contents"=>["x", {"tag"=>"MuNumber", "contents"=>1}]},
   {"tag"=>"Print",
    "contents"=>
     {"tag"=>"Application",
      "contents"=>
       [{"tag"=>"Primitive", "contents"=>"Multiply"}, [{"tag"=>"MuNumber", "contents"=>2}, {"tag"=>"Reference", "contents"=>"x"}]]}}]}
> code.ast serialization: :bracket
=> "[Sequence[Variable[x][MuNumber[1.0]]][Print[Application[Primitive[Multiply]][MuNumber[2.0]][Reference[x]]]]]"
> code.ast serialization: :brace
=> "{Sequence{Variable{x}{MuNumber{1.0}}}{Print{Application{Primitive{Multiply}}{MuNumber{2.0}}{Reference{x}}}}}"
```


# :warning: Warnings

* Rebase after #306
* Rebase after #308   