### PR TITLE
Feature scoped replacer

### DIFF
--- a/spec/TransformerSpec.hs
+++ b/spec/TransformerSpec.hs
@@ -36,6 +36,44 @@ spec = do
 
       transform ast [Replace "IsVariable" None] `shouldBe` Sequence [None, None]
 
+
+    it "transform global scope" $ do
+      let ast = (Sequence [
+                    Variable "x" (MuNumber 5),
+                    Variable "y" (MuNumber 5),
+                    SimpleFunction "m" [] (Sequence [ Variable "x" (MuNumber 5), Return (Reference "x")])])
+
+      transform ast [ReplaceAt GlobalScope "IsVariable:x" None] `shouldBe` (
+                Sequence [
+                    None,
+                    Variable "y" (MuNumber 5),
+                    SimpleFunction "m" [] (Sequence [ Variable "x" (MuNumber 5), Return (Reference "x")])])
+
+      transform ast [ReplaceAt GlobalScope "IsDeclaration:x" None] `shouldBe` (
+                Sequence [
+                    None,
+                    Variable "y" (MuNumber 5),
+                    SimpleFunction "m" [] (Sequence [ Variable "x" (MuNumber 5), Return (Reference "x")])])
+
+      transform ast [ReplaceAt GlobalScope "IsVariable" None] `shouldBe` (
+                Sequence [
+                    None,
+                    None,
+                    SimpleFunction "m" [] (Sequence [ Variable "x" (MuNumber 5), Return (Reference "x")])])
+
+    it "transform local scope" $ do
+      let ast = (Sequence [
+                    Variable "x" (MuNumber 5),
+                    Variable "y" (MuNumber 5),
+                    SimpleFunction "m" [] (Sequence [ Variable "x" (MuNumber 5), Return (Reference "x")])])
+
+      transform ast [ReplaceAt LocalScope "IsVariable:x" None] `shouldBe` (
+                Sequence [
+                    Variable "x" (MuNumber 5),
+                    Variable "y" (MuNumber 5),
+                    SimpleFunction "m" [] (Sequence [None, Return (Reference "x")])])
+
+
     it "transform with crop" $ do
       transform (Sequence [
                     Variable "x" (MuNumber 5),

--- a/src/Language/Mulang/Analyzer/Analysis.hs
+++ b/src/Language/Mulang/Analyzer/Analysis.hs
@@ -38,10 +38,11 @@ module Language.Mulang.Analyzer.Analysis (
   TestAnalysisType(..),
   TransformationSpec,
   TransformationOperation(..),
+  TransformationScope(..),
 
   QueryResult,
 
-  AnalysisResult(..),
+  AnalysisResult,
   GenericAnalysisResult(..),
   ExpectationResult(..)) where
 
@@ -138,11 +139,15 @@ data TestAnalysisType
 type TransformationSpec = [TransformationOperation]
 
 data TransformationOperation
-  =  Alias (Map String Operator)
+  = Alias (Map String Operator)
   | Crop Inspection
+  | CropAt TransformationScope Inspection
   | Normalize NormalizationOptions
   | RenameVariables
-  | Replace Inspection Expression deriving (Show, Eq, Generic)
+  | Replace Inspection Expression
+  | ReplaceAt TransformationScope Inspection Expression deriving (Show, Eq, Generic)
+
+data TransformationScope = GlobalScope | LocalScope deriving (Show, Eq, Generic)
 
 data Language
   =  Json

--- a/src/Language/Mulang/Analyzer/Analysis/Json.hs
+++ b/src/Language/Mulang/Analyzer/Analysis/Json.hs
@@ -48,6 +48,7 @@ instance FromJSON Type
 instance FromJSON Assertion
 instance FromJSON TestAnalysisType
 instance FromJSON TransformationOperation
+instance FromJSON TransformationScope
 instance FromJSON InterpreterOptions
 instance FromJSON Operator
 

--- a/src/Language/Mulang/Analyzer/Transformer.hs
+++ b/src/Language/Mulang/Analyzer/Transformer.hs
@@ -3,14 +3,14 @@ module Language.Mulang.Analyzer.Transformer (
   transformMany,
   transform) where
 
-import Language.Mulang.Analyzer.Analysis (Expectation(..), TransformationSpec, TransformationOperation(..))
+import Language.Mulang.Analyzer.Analysis (Expectation(..), TransformationSpec, TransformationOperation(..), TransformationScope(..))
 import Language.Mulang.Analyzer.ExpectationsCompiler (compileExpectation)
 import Language.Mulang.Ast (Expression)
 import Language.Mulang.Transform.Aliaser (alias)
 import Language.Mulang.Transform.Cropper (crop)
 import Language.Mulang.Transform.Normalizer (normalize)
 import Language.Mulang.Transform.Renamer (rename)
-import Language.Mulang.Transform.Replacer (replace)
+import Language.Mulang.Transform.Replacer (replace, globalReplace, localReplace)
 
 transformMany' :: Expression -> Maybe [TransformationSpec] -> Maybe [Expression]
 transformMany' e =  fmap (transformMany e)
@@ -21,10 +21,15 @@ transformMany e specs = map (transform e) specs
 transform :: Expression -> TransformationSpec -> Expression
 transform e ops = foldl f e ops
   where
-    f e (Alias m)          = alias m e
-    f e (Crop i)            = crop (compileInspection i) e
-    f e (Normalize options) = normalize options e
-    f e (Replace i o)       = replace (compileInspection i) o e
-    f e RenameVariables     = rename e
+    f e (Alias m)              = alias m e
+    f e (Crop i)               = crop replace (compileInspection i) e
+    f e (CropAt s i)           = crop (compileReplaceScope s) (compileInspection i) e
+    f e (Normalize options)    = normalize options e
+    f e (Replace i o)          = replace (compileInspection i) o e
+    f e (ReplaceAt s i o)      = (compileReplaceScope s) (compileInspection i) o e
+    f e RenameVariables        = rename e
 
     compileInspection i = snd . compileExpectation $ (Expectation "*" i)
+
+    compileReplaceScope LocalScope  = localReplace
+    compileReplaceScope GlobalScope = globalReplace

--- a/src/Language/Mulang/Transform/Cropper.hs
+++ b/src/Language/Mulang/Transform/Cropper.hs
@@ -2,10 +2,9 @@ module Language.Mulang.Transform.Cropper (
     crop) where
 
 import Language.Mulang.Ast
-import Language.Mulang.Ast.Visitor
 import Language.Mulang.Inspector (Inspection)
 import Language.Mulang.Transform.Normalizer (normalize, unnormalized, NormalizationOptions(..))
-import Language.Mulang.Transform.Replacer (replace)
+import Language.Mulang.Transform.Replacer (Replacer)
 
-crop :: Inspection -> Expression -> Expression
-crop i = normalize (unnormalized { trimSequences = True, compactSequences = True }) . replace i None
+crop :: Replacer -> Inspection -> Expression -> Expression
+crop replace i = normalize (unnormalized { trimSequences = True, compactSequences = True }) . replace i None


### PR DESCRIPTION
# :dart: Goal

Allow replace and crop to optionally work only at a given scope - either `GlobalScope` or `LocalScope` - using new operation variants `CropAt` and `ReplaceAt`: 

```ruby
Mulang::Code.transformed_asts_many(codes, [
    [
        {tag: :CropAt, contents: [ :GlobalScope, "IsVariable" ]}
    ]
  ])
```
 
