### PR TITLE
Feature identifiers analysis

### DIFF
--- a/gem/lib/mulang/code.rb
+++ b/gem/lib/mulang/code.rb
@@ -6,6 +6,10 @@ module Mulang
       @content  = content
     end
 
+    def identifiers(**options)
+      @language.identifiers @content, **options
+    end
+
     def ast(**options)
       @language.ast @content, **options
     end

--- a/gem/lib/mulang/language.rb
+++ b/gem/lib/mulang/language.rb
@@ -1,24 +1,37 @@
 module Mulang::Language
   class Base
+    def identifiers(content, **options)
+      Mulang.analyse(identifiers_analysis(content, **options), **options)['outputIdentifiers'] rescue nil
+    end
+
+    def identifiers_analysis(content, **options)
+      base_analysis content, {includeOutputIdentifiers: true}, **options
+    end
+
     def transformed_asts(content, operations, **options)
       Mulang.analyse(transformed_asts_analysis(content, operations, **options), **options)['transformedAsts'] rescue nil
     end
 
     def transformed_asts_analysis(content, operations, **options)
+      base_analysis content, {transformationSpecs: operations}, **options
+    end
+
+    def normalization_options(**options)
+      options.except(:serialization).presence
+    end
+
+    private
+
+    def base_analysis(content, spec, **options)
       {
         sample: sample(content),
         spec: {
           expectations: [],
           smellsSet: { tag: 'NoSmells' },
           includeOutputAst: false,
-          transformationSpecs: operations,
           normalizationOptions: normalization_options(options)
-        }.compact
+        }.merge(spec).compact
       }
-    end
-
-    def normalization_options(**options)
-      options.except(:serialization).presence
     end
   end
 
@@ -32,15 +45,7 @@ module Mulang::Language
     end
 
     def ast_analysis(content, **options)
-      {
-        sample: sample(content),
-        spec: {
-          expectations: [],
-          smellsSet: { tag: 'NoSmells' },
-          includeOutputAst: true,
-          normalizationOptions: normalization_options(options)
-        }.compact
-      }
+      base_analysis content, {includeOutputAst: true}, **options
     end
 
     def sample(content)

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -3,11 +3,16 @@ require "spec_helper"
 describe Mulang::Code do
   context 'when language is javascript' do
     let(:code) { Mulang::Code.native('JavaScript', 'let x = 1') }
+    let(:code_with_function) { Mulang::Code.native('JavaScript', 'let x = 1; function m(a, b) { return a + b + x }') }
+
+    it { expect(code_with_function.identifiers).to eq [["x", "m"], ["a", "b", "x"]] }
+
 
     it { expect(code.ast).to eq "tag"=>"Variable", "contents"=>["x", {"tag"=>"MuNumber", "contents"=>1}] }
     it { expect(code.ast serialization: :bracket).to eq "[Variable[x][MuNumber[1.0]]]" }
     it { expect(code.analyse expectations: [], smellsSet: { tag: 'NoSmells' }). to eq 'tag'=>'AnalysisCompleted',
                                                                                       'outputAst'=>nil,
+                                                                                      'outputIdentifiers' => nil,
                                                                                       'transformedAsts' => nil,
                                                                                       'signatures'=>[],
                                                                                       'smells'=>[],
@@ -157,6 +162,7 @@ describe Mulang::Code do
                                                                                       'contents'=>['x', [[[], {
                                                                                         'tag'=>'UnguardedBody',
                                                                                         'contents'=>{'tag'=>'Return', 'contents'=>{'tag'=>'MuNumber', 'contents'=>1}}}]]]},
+                                                                                    'outputIdentifiers' => nil,
                                                                                     'transformedAsts' => nil,
                                                                                     'signatures' => [],
                                                                                     'smells' => [],
@@ -192,6 +198,7 @@ describe Mulang::Code do
                                                                                         'contents'=>['x', [[[], {
                                                                                           'tag'=>'UnguardedBody',
                                                                                           'contents'=>{'tag'=>'Return', 'contents'=>{'tag'=>'MuNumber', 'contents'=>1}}}]]]},
+                                                                                      'outputIdentifiers' => nil,
                                                                                       'transformedAsts' => nil,
                                                                                       'signatures' => [],
                                                                                       'smells' => [],

--- a/src/Language/Mulang/Analyzer.hs
+++ b/src/Language/Mulang/Analyzer.hs
@@ -50,10 +50,16 @@ analyseAst ast spec = do
                              (analyseSmells ast context (smellsSet spec))
                              (analyseSignatures ast (signatureAnalysisType spec))
                              testResults
-                             (analyzeIntermediateLanguage ast spec)
+                             (analyzeOutputAst ast spec)
+                             (analyzeOutputIdentifiers ast spec)
                              (transformMany' ast (transformationSpecs spec))
 
-analyzeIntermediateLanguage :: Expression -> AnalysisSpec -> Maybe Expression
-analyzeIntermediateLanguage ast spec
+analyzeOutputAst :: Expression -> AnalysisSpec -> Maybe Expression
+analyzeOutputAst ast spec
   | fromMaybe False (includeOutputAst spec) = Just ast
+  | otherwise = Nothing
+
+analyzeOutputIdentifiers :: Expression -> AnalysisSpec -> Maybe ([String], [String])
+analyzeOutputIdentifiers ast spec
+  | fromMaybe False (includeOutputIdentifiers spec) = Just (declaredIdentifiers ast, referencedIdentifiers ast)
   | otherwise = Nothing

--- a/src/Language/Mulang/Analyzer/Analysis.hs
+++ b/src/Language/Mulang/Analyzer/Analysis.hs
@@ -86,6 +86,7 @@ data AnalysisSpec = AnalysisSpec {
   transformationSpecs :: Maybe [TransformationSpec],
   domainLanguage :: Maybe DomainLanguage,
   includeOutputAst :: Maybe Bool,
+  includeOutputIdentifiers :: Maybe Bool,
   originalLanguage :: Maybe Language,
   autocorrectionRules :: Maybe AutocorrectionRules,
   normalizationOptions :: Maybe NormalizationOptions
@@ -180,6 +181,7 @@ data GenericAnalysisResult a
       signatures :: [Code],
       testResults :: [TestResult],
       outputAst :: Maybe a,
+      outputIdentifiers :: Maybe ([String], [String]),
       transformedAsts :: Maybe [a] }
   | AnalysisFailed { reason :: String } deriving (Show, Eq, Generic)
 
@@ -215,6 +217,7 @@ emptyAnalysisSpec = AnalysisSpec {
     transformationSpecs = Nothing,
     domainLanguage = Nothing,
     includeOutputAst = Nothing,
+    includeOutputIdentifiers = Nothing,
     originalLanguage = Nothing,
     autocorrectionRules = Nothing,
     normalizationOptions = Nothing
@@ -242,7 +245,7 @@ testsAnalysis :: Fragment -> TestAnalysisType -> Analysis
 testsAnalysis code testAnalysisType = Analysis code (emptyAnalysisSpec { testAnalysisType = Just testAnalysisType })
 
 emptyCompletedAnalysisResult :: AnalysisResult
-emptyCompletedAnalysisResult = AnalysisCompleted [] [] [] [] Nothing Nothing
+emptyCompletedAnalysisResult = AnalysisCompleted [] [] [] [] Nothing Nothing Nothing
 
 emptyDomainLanguage :: DomainLanguage
 emptyDomainLanguage = DomainLanguage Nothing Nothing Nothing Nothing


### PR DESCRIPTION
# :dart: Goal

To allow declared and references identifiers to be extracted as part of analysis.

```ruby
> code = Mulang::Code.native('JavaScript', 'let x = 1; function m(a, b) { return a + b + x }')
> code.identifiers
=> [["x", "m"], ["a", "b", "x"]] }
```

# :warning: Warning

Rebase after #310 