### PR TITLE
Removing deprecated AST elements

### DIFF
--- a/src/Language/Mulang/Ast.hs
+++ b/src/Language/Mulang/Ast.hs
@@ -111,8 +111,6 @@ data Expression
     | Procedure Identifier SubroutineBody
     -- ^ Imperative programming procedure declaration. It is composed by a name and one or more equations
     | Method Identifier SubroutineBody
-    | EqualMethod SubroutineBody -- deprecated
-    | HashMethod SubroutineBody -- deprecated
     | PrimitiveMethod Operator SubroutineBody
     | Variable Identifier Expression
     | Constant Identifier Expression
@@ -190,8 +188,6 @@ data Expression
     -- ^ Generic sequence of statements
     | Other (Maybe Code) (Maybe Expression)
     -- ^ Unrecognized expression, with optional description and body
-    | Equal -- ^ deprecated
-    | NotEqual -- ^ deprecated
     | Arrow Expression Expression
     -- ^ Generic arrow - AKA pair or entry - that is typically used to build dictionaries.
     -- It corresponds to ruby's, perl's and php's `=>` operator, or ruby's and javascript's `:` operator

--- a/src/Language/Mulang/Ast/Visitor.hs
+++ b/src/Language/Mulang/Ast/Visitor.hs
@@ -53,10 +53,8 @@ extractTerminal (Record _)          = True
 extractTerminal (Reference _)       = True
 extractTerminal (TypeAlias _ _)     = True
 extractTerminal (TypeSignature _ _) = True
-extractTerminal Equal               = True
 extractTerminal MuNil               = True
 extractTerminal None                = True
-extractTerminal NotEqual            = True
 extractTerminal Self                = True
 extractTerminal _                   = False
 
@@ -121,9 +119,7 @@ pattern SingleEquationsList es e <- (extractSingleEquationsList -> Just (es, e))
 
 extractSingleEquationsList :: Expression -> Maybe ([Equation],
                                                    [Equation] -> Expression)
-extractSingleEquationsList (EqualMethod eqs)       = Just (eqs, (EqualMethod))
 extractSingleEquationsList (Function v eqs)        = Just (eqs, (Function v))
-extractSingleEquationsList (HashMethod eqs)        = Just (eqs, (HashMethod))
 extractSingleEquationsList (Method v eqs)          = Just (eqs, (Method v))
 extractSingleEquationsList (PrimitiveMethod v eqs) = Just (eqs, (PrimitiveMethod v))
 extractSingleEquationsList (Procedure v eqs)       = Just (eqs, (Procedure v))

--- a/src/Language/Mulang/Inspector/Smell.hs
+++ b/src/Language/Mulang/Inspector/Smell.hs
@@ -72,8 +72,6 @@ isLongCode = containsExpression f
 compares :: (Expression -> Bool) -> Inspection
 compares f = containsExpression (any f.comparisonOperands)
 
-comparisonOperands (Call Equal                     [a1, a2])   = [a1, a2] -- deprecated
-comparisonOperands (Call NotEqual                  [a1, a2])   = [a1, a2] -- deprecated
 comparisonOperands (Call (Primitive O.Like)        [a1, a2])   = [a1, a2]
 comparisonOperands (Call (Primitive O.NotLike)     [a1, a2])   = [a1, a2]
 comparisonOperands _                                           = []
@@ -186,17 +184,13 @@ overridesEqualOrHashButNotBoth :: Inspection
 overridesEqualOrHashButNotBoth = containsExpression f
   where f (Sequence expressions) = (any isEqual expressions) /= (any isHash expressions)
         f (Class _ _ (PrimitiveMethod O.Like     _)) = True
-        f (Class _ _ (EqualMethod _))                = True
         f (Class _ _ (PrimitiveMethod O.Hash _))     = True
-        f (Class _ _ (HashMethod _))                 = True
         f _ = False
 
         isEqual (PrimitiveMethod O.Like     _) = True
-        isEqual (EqualMethod _)                = True -- deprecated
         isEqual _ = False
 
         isHash (PrimitiveMethod O.Hash _) = True
-        isHash (HashMethod _)             = True -- deprecated
         isHash _ = False
 
 shouldInvertIfCondition :: Inspection


### PR DESCRIPTION
Dropping support for `Equal`, `NotEqual`, `HashMethod` and `EqualMethod`.  They were deprecated long ago