### PR TITLE
Allow serialization of external languages

### DIFF
--- a/gem/lib/mulang/language.rb
+++ b/gem/lib/mulang/language.rb
@@ -20,6 +20,14 @@ module Mulang::Language
       options.except(:serialization).presence
     end
 
+    def ast(content, **options)
+      Mulang.analyse(ast_analysis(content, **options), **options)['outputAst'] rescue nil
+    end
+
+    def ast_analysis(content, **options)
+      base_analysis content, {includeOutputAst: true}, **options
+    end
+
     private
 
     def base_analysis(content, spec, **options)
@@ -40,14 +48,6 @@ module Mulang::Language
       @language = language
     end
 
-    def ast(content, **options)
-      Mulang.analyse(ast_analysis(content, **options), **options)['outputAst'] rescue nil
-    end
-
-    def ast_analysis(content, **options)
-      base_analysis content, {includeOutputAst: true}, **options
-    end
-
     def sample(content)
       {
         tag: 'CodeSample',
@@ -63,14 +63,24 @@ module Mulang::Language
     end
 
     def ast(content, **args)
-      @tool.call(content) rescue nil
+      if args[:serialization]
+        super
+      else
+        call_tool content
+      end
     end
 
     def sample(content)
       {
         tag: 'MulangSample',
-        ast: ast(content)
+        ast: call_tool(content)
       }
+    end
+
+    private
+
+    def call_tool(content)
+      @tool.call(content) rescue nil
     end
   end
 end

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -150,6 +150,9 @@ describe Mulang::Code do
     end
     let(:code) { Mulang::Code.external(input) }
 
+    it { expect(code.ast).to eq input }
+    it { expect(code.ast serialization: :bracket).to eq "[Procedure[x][Equation[UnguardedBody[MuNumber[1.0]]]]]" }
+
     it do
       expect(code.sample).to eq tag: 'MulangSample', ast: input
     end


### PR DESCRIPTION
# :dart: Goal

To allow `External` languages to be serialized, since `ast` method returns them as-is otherwise. 

# :memo: Details

See discussion about this PR [here ](https://github.com/mumuki/mulang/pull/312#discussion_r560382012)

