### PR TITLE
Infer language from mulang sample

### DIFF
--- a/spec/AutocorrectorSpec.hs
+++ b/spec/AutocorrectorSpec.hs
@@ -17,8 +17,14 @@ runWithCustomRules language code rules e = transform (Analysis
 spec :: Spec
 spec = do
   describe "correct custom usages" $ do
-    it "corrects given rules when using MulangSample" $ do
+    it "corrects given rules when using MulangSample and originalLanguage" $ do
       let setting = runWithCustomRules (Just Ruby) (MulangSample None) [("Uses:foo", "UsesPlus")]
+
+      setting (Expectation "*" "UsesPlus")  `shouldBe` (Expectation "*" "UsesPlus")
+      setting (Expectation "*" "Uses:foo")  `shouldBe` (Expectation "*" "UsesPlus")
+
+    it "corrects given rules when using MulangSample and no originalLanguage" $ do
+      let setting = runWithCustomRules Nothing (MulangSample None) [("Uses:foo", "UsesPlus")]
 
       setting (Expectation "*" "UsesPlus")  `shouldBe` (Expectation "*" "UsesPlus")
       setting (Expectation "*" "Uses:foo")  `shouldBe` (Expectation "*" "UsesPlus")

--- a/src/Language/Mulang/Analyzer/Analysis.hs
+++ b/src/Language/Mulang/Analyzer/Analysis.hs
@@ -151,8 +151,7 @@ data TransformationOperation
 data TransformationScope = GlobalScope | LocalScope deriving (Show, Eq, Generic)
 
 data Language
-  =  Json
-  |  Java
+  =  Java
   |  JavaScript
   |  Prolog
   |  Haskell
@@ -162,6 +161,7 @@ data Language
   |  Ruby
   |  Php
   |  C
+  |  Mulang
   deriving (Show, Eq, Generic)
 
 --

--- a/src/Language/Mulang/Analyzer/Autocorrector.hs
+++ b/src/Language/Mulang/Analyzer/Autocorrector.hs
@@ -30,7 +30,7 @@ import qualified Data.Map.Strict as Map
 --
 -- It performs the following corrections:
 --
---  1. fills originalLanguage when it is not present but can be inferred from the code sample
+--  1. fills originalLanguage when it is not present but can be inferred from the code or mulang sample
 --  2. fills the autocorrectionRules when they are not present but can be inferred from the originalLanguage
 --  3. aguments the autocorrectionRules with operators-based rules when they can be inferred from the originalLanguage
 --  4. corrects the expectations' inspections using the autocorrectionRules
@@ -39,8 +39,8 @@ import qualified Data.Map.Strict as Map
 --  7. fills the normalizationOption when they are not present but can be inferred from the originalLanguage
 autocorrect :: Analysis -> Analysis
 autocorrect (Analysis f s@(AnalysisSpec { originalLanguage = Just _ })) = Analysis f (autocorrectSpec s)
+autocorrect (Analysis f@(MulangSample _) s)                             = autocorrect (Analysis f s { originalLanguage = Just Json }) -- (1)
 autocorrect (Analysis f@(CodeSample { language = l } ) s)               = autocorrect (Analysis f s { originalLanguage = Just l }) -- (1)
-autocorrect a                                                           = a
 
 autocorrectSpec :: AnalysisSpec -> AnalysisSpec
 autocorrectSpec s = runFixes [

--- a/src/Language/Mulang/Analyzer/Autocorrector.hs
+++ b/src/Language/Mulang/Analyzer/Autocorrector.hs
@@ -39,7 +39,7 @@ import qualified Data.Map.Strict as Map
 --  7. fills the normalizationOption when they are not present but can be inferred from the originalLanguage
 autocorrect :: Analysis -> Analysis
 autocorrect (Analysis f s@(AnalysisSpec { originalLanguage = Just _ })) = Analysis f (autocorrectSpec s)
-autocorrect (Analysis f@(MulangSample _) s)                             = autocorrect (Analysis f s { originalLanguage = Just Json }) -- (1)
+autocorrect (Analysis f@(MulangSample _) s)                             = autocorrect (Analysis f s { originalLanguage = Just Mulang }) -- (1)
 autocorrect (Analysis f@(CodeSample { language = l } ) s)               = autocorrect (Analysis f s { originalLanguage = Just l }) -- (1)
 
 autocorrectSpec :: AnalysisSpec -> AnalysisSpec


### PR DESCRIPTION
# :dart: Goal

Allow autocorrection subsystem to work with `MulangSample` when an original true language can not be given - and as a consequence - can nor inferred.

## :arrow_backward: Before

```ruby
Mulang::Code.external(tag: :None) {|it|it}.analyse expectations: [{binding: "*", inspection: "Uses:foo"}], autocorrectionRules: {"Uses:foo" => "UsesIf"}

=> {"outputIdentifiers"=>nil,
 "tag"=>"AnalysisCompleted",
 "testResults"=>[],
 "signatures"=>[],
 "transformedAsts"=>nil,
 "smells"=>[],
 "expectationResults"=>[{"result"=>false, "expectation"=>{"inspection"=>"Uses:foo", "binding"=>"*"}}],
 "outputAst"=>nil}
```

## :arrow_forward: After

```ruby
Mulang::Code.external(tag: :None) {|it|it}.analyse expectations: [{binding: "*", inspection: "Uses:foo"}], autocorrectionRules: {"Uses:foo" => "UsesIf"}
=> {"outputIdentifiers"=>nil,
 "tag"=>"AnalysisCompleted",
 "testResults"=>[],
 "signatures"=>[],
 "transformedAsts"=>nil,
 "smells"=>[],
 "expectationResults"=>[{"result"=>false, "expectation"=>{"inspection"=>"UsesIf", "binding"=>"*"}}],
 "outputAst"=>nil}
```

# :memo: Details

I have removed an ancient `Json` language. This is just vestigial. See 7f609b8