### PR TITLE
Fix multiply operator hides wildcard

### DIFF
--- a/spec/AutocorrectorSpec.hs
+++ b/spec/AutocorrectorSpec.hs
@@ -36,7 +36,7 @@ spec = do
       setting (Expectation "*" "Uses:foo")  `shouldBe` (Expectation "*" "UsesPlus")
 
   describe "correct primitive usages" $ do
-    it "corrects never corrects *" $ do
+    it "never corrects plain *" $ do
       let uses = Expectation "*" "Uses:*"
 
       run Mulang uses `shouldBe` uses
@@ -44,6 +44,23 @@ spec = do
       run JavaScript uses `shouldBe` uses
       run Prolog uses `shouldBe` uses
       run Php uses `shouldBe` uses
+
+    it "always corrects plain * with strict match " $ do
+      let strictUses = Expectation "*" "Uses:=*"
+      let usesMultiply = Expectation "*" "UsesMultiply"
+
+      run Mulang strictUses `shouldBe` strictUses
+
+      run Ruby strictUses `shouldBe` usesMultiply
+      run JavaScript strictUses `shouldBe` usesMultiply
+      run Prolog strictUses `shouldBe` usesMultiply
+      run Php strictUses `shouldBe` usesMultiply
+
+    it "corrects operators when strict match" $ do
+      run Java (Expectation "*" "Uses:=+") `shouldBe` (Expectation "*" "UsesPlus")
+      run Haskell (Expectation "*" "Uses:=-") `shouldBe` (Expectation "*" "UsesMinus")
+      run JavaScript (Expectation "*" "Uses:====") `shouldBe` (Expectation "*" "UsesEqual")
+      run JavaScript (Expectation "*" "Uses:===") `shouldBe` (Expectation "*" "UsesSimilar")
 
     it "corrects haskell otherwise negated" $ do
       run Haskell (Expectation "*" "Not:Uses:otherwise")  `shouldBe` (Expectation "*" "Not:UsesOtherwise")

--- a/spec/AutocorrectorSpec.hs
+++ b/spec/AutocorrectorSpec.hs
@@ -36,6 +36,15 @@ spec = do
       setting (Expectation "*" "Uses:foo")  `shouldBe` (Expectation "*" "UsesPlus")
 
   describe "correct primitive usages" $ do
+    it "corrects never corrects *" $ do
+      let uses = Expectation "*" "Uses:*"
+
+      run Mulang uses `shouldBe` uses
+      run Ruby uses `shouldBe` uses
+      run JavaScript uses `shouldBe` uses
+      run Prolog uses `shouldBe` uses
+      run Php uses `shouldBe` uses
+
     it "corrects haskell otherwise negated" $ do
       run Haskell (Expectation "*" "Not:Uses:otherwise")  `shouldBe` (Expectation "*" "Not:UsesOtherwise")
 

--- a/src/Language/Mulang/Analyzer/Synthesizer.hs
+++ b/src/Language/Mulang/Analyzer/Synthesizer.hs
@@ -56,10 +56,13 @@ generateOperatorEncodingRules :: EncodingRuleGenerator Token Operator
 generateOperatorEncodingRules = generateEncodingRules encodeUsageInspection encodeDeclarationInspection
 
 generateEncodingRules :: Encoder a -> Encoder a -> EncodingRuleGenerator Token a
-generateEncodingRules _            _                  ("*", _) = []
-generateEncodingRules usageEncoder declarationEncoder (k, v)   = concatMap generateEncodingNegationRules baseEncodings
+generateEncodingRules usageEncoder declarationEncoder = baseMatchers >=> generateBaseEncodingRules >=> generateNegationEncodingRules
   where
-    baseEncodings = [("Uses:" ++ k, usageEncoder v), ("Declares:" ++ k, declarationEncoder v)]
+    baseMatchers ("*", v)      = [("=*", v)]
+    baseMatchers (('=':xs), v) = [(('=':'=':xs), v)]
+    baseMatchers (k, v)        = [(k, v), ("=" ++ k, v)]
 
-    generateEncodingNegationRules :: EncodingRuleGenerator Inspection Inspection
-    generateEncodingNegationRules (k, v) = [(k, v), ("Not:" ++ k, "Not:" ++ v)]
+    generateBaseEncodingRules (k, v) = [("Uses:" ++ k, usageEncoder v), ("Declares:" ++ k, declarationEncoder v)]
+
+    generateNegationEncodingRules :: EncodingRuleGenerator Inspection Inspection
+    generateNegationEncodingRules (k, v) = [(k, v), ("Not:" ++ k, "Not:" ++ v)]

--- a/src/Language/Mulang/Analyzer/Synthesizer.hs
+++ b/src/Language/Mulang/Analyzer/Synthesizer.hs
@@ -56,7 +56,8 @@ generateOperatorEncodingRules :: EncodingRuleGenerator Token Operator
 generateOperatorEncodingRules = generateEncodingRules encodeUsageInspection encodeDeclarationInspection
 
 generateEncodingRules :: Encoder a -> Encoder a -> EncodingRuleGenerator Token a
-generateEncodingRules usageEncoder declarationEncoder (k, v) = concatMap generateEncodingNegationRules baseEncodings
+generateEncodingRules _            _                  ("*", _) = []
+generateEncodingRules usageEncoder declarationEncoder (k, v)   = concatMap generateEncodingNegationRules baseEncodings
   where
     baseEncodings = [("Uses:" ++ k, usageEncoder v), ("Declares:" ++ k, declarationEncoder v)]
 


### PR DESCRIPTION
# :dart: Goal

This is a fix to a severe issue regarding autocorrection rules - the multiply operator is hiding the wildcard asterisk in `Uses:*` and `Declares:*`.  The solution here is to just don't generate autocorrection rules for this token. 

# :memo: Details

This PR adds support for strict matching (`=`) with autocorrection rules, and a few exceptions for wildcard asterisk `*` and operators that start with `=`. 
 
## General `$token` token

* `Uses:$token`
* `Uses:=$token`
* `Not:Uses:$token`
* `Not:Uses:=$token`
* `Declares:$token`
* `Declares:=$token`
* `Not:Declares:$token`
* `Not:Declares:=$token`

## `*` token

* `Uses:=*`
* `Not:Uses:=*`
* `Declares:=*`
* `Not:Declares:=*`

## Tokens that start with `=`

E.g `===`: 

* `Uses:====`
* `Not:Uses:====`
* `Declares:====`
* `Not:Declares:====`

Notice the additional fourth `=` .


