### PR TITLE
Accept and use originalLanguage in External

### DIFF
--- a/gem/lib/mulang/code.rb
+++ b/gem/lib/mulang/code.rb
@@ -60,8 +60,8 @@ module Mulang
       native(*args).tap { |it| it.expect('Parses') }
     end
 
-    def self.external(content, &tool)
-      new Mulang::Language::External.new(&tool), content
+    def self.external(language_name = nil, content, &tool)
+      new Mulang::Language::External.new(language_name, &tool), content
     end
 
     def self.analyse_many(codes, spec, **options)

--- a/gem/lib/mulang/language.rb
+++ b/gem/lib/mulang/language.rb
@@ -44,21 +44,26 @@ module Mulang::Language
   end
 
   class Native < Base
-    def initialize(language)
-      @language = language
+    attr_accessor :name
+
+    def initialize(language_name)
+      @name = language_name
     end
 
     def sample(content)
       {
         tag: 'CodeSample',
-        language: @language,
+        language: @name,
         content: content
       }
     end
   end
 
   class External < Base
-    def initialize(&tool)
+    attr_accessor :name
+
+    def initialize(language_name = nil, &tool)
+      @name = language_name
       @tool = block_given? ? tool : proc { |it| it }
     end
 
@@ -75,6 +80,10 @@ module Mulang::Language
         tag: 'MulangSample',
         ast: call_tool(content)
       }
+    end
+
+    def base_analysis(*)
+      super.deep_merge(spec: {originalLanguage: @name}.compact)
     end
 
     private

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -175,6 +175,20 @@ describe Mulang::Code do
     end
   end
 
+  context 'when language is external with original language name' do
+    let(:code) { Mulang::Code.external('Ruby', tag: :None) }
+    it { expect(code.language.name).to eq 'Ruby' }
+    it { expect(code.ast_analysis[:spec][:originalLanguage]).to eq 'Ruby' }
+    it { expect(code.ast serialization: :bracket).to eq '[None]' }
+  end
+
+  context 'when language is external with no original language name' do
+    let(:code) { Mulang::Code.external(tag: :None) }
+    it { expect(code.language.name).to be nil }
+    it { expect(code.ast_analysis[:spec][:originalLanguage]).to be nil }
+    it { expect(code.ast serialization: :bracket).to eq '[None]' }
+  end
+
   context 'when language is native with normalization options' do
     let(:input) do
       'function x() { 1 }'


### PR DESCRIPTION
:dart: Goal

To allow passing `originalLanguage` to all specs in `Mulang::Language::External`. This is necessary to activate language-specific autocorrection rules - currently this is only true for `Ruby` and `Php`