### PR TITLE
Fixes to HasRedundantVariableReturn

### DIFF
--- a/gem/lib/mulang/expectation.rb
+++ b/gem/lib/mulang/expectation.rb
@@ -26,7 +26,6 @@ module Mulang::Expectation
     HasAssignmentCondition
     HasAssignmentReturn
     HasEmptyRepeat
-    HasRedundantLocalVariableReturn
     HasRedundantRepeat
   )
 
@@ -47,6 +46,7 @@ module Mulang::Expectation
     HasEqualIfBranches
     HasLongParameterList
     HasRedundantBooleanComparison
+    HasRedundantLocalVariableReturn
     HasRedundantIf
     HasRedundantLambda
     HasTooShortBindings

--- a/spec/SmellSpec.hs
+++ b/spec/SmellSpec.hs
@@ -117,6 +117,9 @@ spec = do
     it "is True when local variable is not necessary" $ do
       hasRedundantLocalVariableReturn (js "function x(m) { let x  = 5; return x; }") `shouldBe` True
 
+    it "is True when local variable is not necessary and there are previous statements" $ do
+      hasRedundantLocalVariableReturn (js "function x(m) { let z = 0; let x  = 5; return x; }") `shouldBe` True
+
     it "is False when local variable is not necessary, but there are many variables" $ do
       hasRedundantLocalVariableReturn (js "function x(m) { let x = 5; let y = 2; return x; }") `shouldBe` False
 

--- a/src/Language/Mulang/Inspector/Smell.hs
+++ b/src/Language/Mulang/Inspector/Smell.hs
@@ -141,9 +141,10 @@ isBooleanLiteral _          = False
 
 hasRedundantLocalVariableReturn :: Inspection
 hasRedundantLocalVariableReturn = containsExpression f
-  where f (Sequence [ Variable declaredVariable _,
-                      Return (Reference returnedVariable)]) = returnedVariable == declaredVariable
-        f _                                                 = False
+  where f (Sequence (reverse ->
+                      (Return (Reference returnedVariable) :
+                        Variable declaredVariable _:_))) = returnedVariable == declaredVariable
+        f _                                              = False
 
 hasAssignmentCondition :: Inspection
 hasAssignmentCondition = containsExpression f


### PR DESCRIPTION
# :dart: Goal

To promote this smell to general smells set, and to make it work with callables longer than  2 statements. 

