### PR TITLE
Chore improve backwards compatibility

### DIFF
--- a/docs/edlspec.md
+++ b/docs/edlspec.md
@@ -391,6 +391,7 @@ Not all inspections can be counted. Currently, only the following are supported:
 * `declares procedure`
 * `declares variable`
 * `returns`
+* `uses`
 * `uses for each`
 * `uses for loop`
 * `uses for`
@@ -402,6 +403,7 @@ Not all inspections can be counted. Currently, only the following are supported:
 * `uses try`
 * `uses while`
 * `uses yield`
+* All the [primitive operator inspections](./inspections/#primitive-operator-inspections), e.g. `uses plus` or `uses size`
 
 ## Boolean operators on scoped queries
 

--- a/docs/edlspec.md
+++ b/docs/edlspec.md
@@ -28,6 +28,14 @@ expectation:
 
 ...which is just syntactic sugar - the `something` keyword is just a dummy token you can add to make the expectation syntax more human-readable.
 
+Likewise, you can use `somewhere` keyword in order to be more explicit about using an _unscoped_ query - more on this later:
+
+```edl
+expectation:
+  %% equivalent to previous example, `somewhere` is just a dummy token
+  somewhere calls something;
+```
+
 Although you can declare unnamed expectations, it is usually more convenient to add an intention-revealing name:
 
 ```edl

--- a/docs/inspections.md
+++ b/docs/inspections.md
@@ -63,12 +63,11 @@ The power of Mulang is grounded on more than 120 different kind of inspections
 | `UsesIf`                          | is an `if` control structure used?
 | `UsesLogic`                       | are boolean operators used?
 | `UsesMath`                        | are artithmetic operators used?
-| `UsesPrimitive`                   | is the given primitive operator used?
 | `UsesPrint`                       | is a print statement used?
 | `UsesType`                        | is the given typed used in a signature?
 
 
-## Operator Inspections
+## Primitive Operator Inspections
 
 > 👀 See also [operators section in AST Specs](./astspec/#primitive-operators).
 >

--- a/spec/CustomExpectationsAnalyzerSpec.hs
+++ b/spec/CustomExpectationsAnalyzerSpec.hs
@@ -219,6 +219,16 @@ spec = describe "ExpectationsAnalyzer" $ do
     -- (run JavaScript "let x = ! y" "expectation: uses `!`") `shouldReturn` nok
     pendingWith "autocorrector does not work with EDL"
 
+  it "evaluates count ( uses negation )" $ do
+    (run Haskell "x = not $ not y" "expectation: count ( uses negation ) >= 1") `shouldReturn` ok
+    (run Haskell "x = not y" "expectation: count ( uses negation ) >= 1") `shouldReturn` ok
+    (run Haskell "x = y" "expectation: count ( uses negation ) >= 1") `shouldReturn` nok
+
+  it "evaluates count calls" $ do
+    (run JavaScript "let x = f(f(y))" "expectation: count ( uses `f` ) >= 1") `shouldReturn` ok
+    (run JavaScript "let x = f(y)" "expectation: count ( uses `f` ) >= 1") `shouldReturn` ok
+    (run JavaScript "let x = y" "expectation: count ( uses `f` ) >= 1") `shouldReturn` nok
+
   it "evaluates uses negation" $ do
     let test = "expectation: uses negation"
 

--- a/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
+++ b/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
@@ -72,27 +72,29 @@ compileVerb = concat . map headToUpper . words
 compileCounter :: String -> E.Matcher -> Maybe (ContextualizedBoundCounter)
 compileCounter = f
   where
-  f "Calls"               = boundMatching countCalls
-  f "DeclaresAttribute"   = boundMatching countAttributes
-  f "DeclaresClass"       = boundMatching countClasses
-  f "DeclaresFunction"    = boundMatching countFunctions
-  f "DeclaresInterface"   = boundMatching countInterfaces
-  f "DeclaresMethod"      = boundMatching countMethods
-  f "DeclaresObject"      = boundMatching countObjects
-  f "DeclaresProcedure"   = boundMatching countProcedures
-  f "DeclaresVariable"    = boundMatching countVariables
-  f "Returns"             = plainMatching countReturns
-  f "UsesFor"             = plainMatching countFors
-  f "UsesForEach"         = plainMatching countForEaches
-  f "UsesForLoop"         = plainMatching countForLoops
-  f "UsesIf"              = plainMatching countIfs
-  f "UsesLambda"          = plainMatching countLambdas
-  f "UsesPrint"           = plainMatching countPrints
-  f "UsesRepeat"          = plainMatching countRepeats
-  f "UsesSwitch"          = plainMatching countSwitches
-  f "UsesWhile"           = plainMatching countWhiles
-  f "UsesYield"           = plainMatching countYiels
-  f _                     = const Nothing
+  f "Calls"                      m            = boundMatching countCalls m
+  f "DeclaresAttribute"          m            = boundMatching countAttributes m
+  f "DeclaresClass"              m            = boundMatching countClasses m
+  f "DeclaresFunction"           m            = boundMatching countFunctions m
+  f "DeclaresInterface"          m            = boundMatching countInterfaces m
+  f "DeclaresMethod"             m            = boundMatching countMethods m
+  f "DeclaresObject"             m            = boundMatching countObjects m
+  f "DeclaresProcedure"          m            = boundMatching countProcedures m
+  f "DeclaresVariable"           m            = boundMatching countVariables m
+  f "Returns"                    m            = plainMatching countReturns m
+  f "Uses"                       E.Unmatching = bound countUses
+  f "UsesFor"                    m            = plainMatching countFors m
+  f "UsesForEach"                m            = plainMatching countForEaches m
+  f "UsesForLoop"                m            = plainMatching countForLoops m
+  f "UsesIf"                     m            = plainMatching countIfs m
+  f "UsesLambda"                 m            = plainMatching countLambdas m
+  f "UsesPrint"                  m            = plainMatching countPrints m
+  f "UsesRepeat"                 m            = plainMatching countRepeats m
+  f "UsesSwitch"                 m            = plainMatching countSwitches m
+  f "UsesWhile"                  m            = plainMatching countWhiles m
+  f "UsesYield"                  m            = plainMatching countYiels m
+  f (primitiveUsage -> Just p)   E.Unmatching = plain (countUsesPrimitive p)
+  f _                            _            = Nothing
 
 
 compileInspection :: String -> E.Matcher -> Maybe ContextualizedBoundInspection
@@ -186,9 +188,9 @@ compileInspection = f
   f (primitiveEssence -> Just p)       E.Unmatching   = plain (isPrimitive p)
   f _                                  _              = Nothing
 
-  primitiveEssence = decodeIsInspection
-  primitiveUsage = decodeUsageInspection
-  primitiveDeclaration = decodeDeclarationInspection
+primitiveEssence = decodeIsInspection
+primitiveUsage = decodeUsageInspection
+primitiveDeclaration = decodeDeclarationInspection
 
 contextual :: ContextualizedConsult a -> Maybe (ContextualizedBoundConsult a)
 contextual = Just . contextualizedBind

--- a/src/Language/Mulang/Inspector/Family.hs
+++ b/src/Language/Mulang/Inspector/Family.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE LiberalTypeSynonyms #-}
 
 module Language.Mulang.Inspector.Family (
+  deriveSpecial,
   deriveUses,
   deriveDeclares,
   InspectionFamily,
@@ -16,8 +17,13 @@ type Family a = ((a Bool), Matcher -> (a Bool), Matcher -> (a Count))
 type InspectionFamily = Family Consult
 type BoundInspectionFamily = Family BoundConsult
 
+-- | Derives a non-standard family of inspections from a primal inspection that takes a generic argument,
+-- which consist of just an inspection and a counter
+deriveSpecial :: (a -> Inspection) -> (a -> Inspection, a -> Counter)
+deriveSpecial f = (positive . f', f')
+  where f' = countExpressions . f
 
--- | Derives a family of usage inspections from a primal   inspection,
+-- | Derives a family of usage inspections from a primal inspection,
 -- which consist of a simple inspection, a matching inspection and a counter
 deriveUses :: (Matcher -> Inspection) -> InspectionFamily
 deriveUses f = (uses, usesMatching, countUses)

--- a/src/Language/Mulang/Inspector/Generic.hs
+++ b/src/Language/Mulang/Inspector/Generic.hs
@@ -61,7 +61,7 @@ import Language.Mulang.Inspector.Matcher (unmatching, matches, Matcher)
 import Language.Mulang.Inspector.Query (inspect, select)
 import Language.Mulang.Inspector.Literal (isMath, isLogic)
 import Language.Mulang.Inspector.Combiner (transitive)
-import Language.Mulang.Inspector.Family (deriveUses, deriveDeclares, InspectionFamily, BoundInspectionFamily)
+import Language.Mulang.Inspector.Family (deriveSpecial, deriveUses, deriveDeclares, InspectionFamily, BoundInspectionFamily)
 
 import Data.Maybe (listToMaybe)
 import Data.List.Extra (has)
@@ -80,18 +80,10 @@ assignsMatching matcher predicate = containsExpression f
 
 -- | Inspection that tells whether an expression uses the the given target identifier
 -- in its definition
-uses :: BoundInspection
-uses = positive . countUses
+(uses, countUses) = deriveSpecial f :: (BoundInspection, BoundCounter)
+  where f p = any p . referencedIdentifiers
 
-countUses :: BoundCounter
-countUses p = countExpressions f
-  where f = any p . referencedIdentifiers
-
-usesPrimitive :: Operator -> Inspection
-usesPrimitive  = positive . countUsesPrimitive
-
-countUsesPrimitive :: Operator -> Counter
-countUsesPrimitive operator = countExpressions (isPrimitive operator)
+(usesPrimitive, countUsesPrimitive) = deriveSpecial isPrimitive :: (Operator -> Inspection, Operator -> Counter)
 
 isPrimitive :: Operator -> Inspection
 isPrimitive operator (Primitive o) = operator == o

--- a/src/Language/Mulang/Inspector/Generic.hs
+++ b/src/Language/Mulang/Inspector/Generic.hs
@@ -33,6 +33,7 @@ module Language.Mulang.Inspector.Generic (
   subordinatesDeclarationsToEntryPoint,
   isPrimitive,
   uses,
+  countUses,
   usesAnonymousVariable,
   usesExceptionHandling,
   usesExceptions,
@@ -43,6 +44,7 @@ module Language.Mulang.Inspector.Generic (
   usesLogic,
   usesMath,
   usesPrimitive,
+  countUsesPrimitive,
   usesPrint,
   usesPrintMatching,
   usesYield,
@@ -79,11 +81,17 @@ assignsMatching matcher predicate = containsExpression f
 -- | Inspection that tells whether an expression uses the the given target identifier
 -- in its definition
 uses :: BoundInspection
-uses p = containsExpression f
+uses = positive . countUses
+
+countUses :: BoundCounter
+countUses p = countExpressions f
   where f = any p . referencedIdentifiers
 
 usesPrimitive :: Operator -> Inspection
-usesPrimitive operator = containsExpression (isPrimitive operator)
+usesPrimitive  = positive . countUsesPrimitive
+
+countUsesPrimitive :: Operator -> Counter
+countUsesPrimitive operator = countExpressions (isPrimitive operator)
 
 isPrimitive :: Operator -> Inspection
 isPrimitive operator (Primitive o) = operator == o


### PR DESCRIPTION
# :dart: Goal

Add support for counting `uses` and `usesPrimtive`. Otherwise there are no equivalents of counting operators that became primitives in mulang 6