### PR TITLE
Add ruby size operators

### DIFF
--- a/spec/AutocorrectorSpec.hs
+++ b/spec/AutocorrectorSpec.hs
@@ -97,6 +97,10 @@ spec = do
       run Ruby (Expectation "*" "Uses:and") `shouldBe` (Expectation "*" "UsesAnd")
       run Ruby (Expectation "*"  "Uses:&&") `shouldBe` (Expectation "*" "UsesAnd")
 
+    it "corrects ruby size" $ do
+      run Ruby (Expectation "*" "Uses:size") `shouldBe` (Expectation "*" "UsesSize")
+      run Ruby (Expectation "*"  "Uses:length") `shouldBe` (Expectation "*" "UsesSize")
+
     it "corrects JS operators" $ do
       run JavaScript (Expectation "*" "Uses:+") `shouldBe` (Expectation "*" "UsesPlus")
       run JavaScript (Expectation "*" "Uses:&&") `shouldBe` (Expectation "*" "UsesAnd")

--- a/tokens.yml
+++ b/tokens.yml
@@ -156,6 +156,9 @@ Ruby:
     Switch: 'case'
   operators:
     <<: *common_operators
+    Size:
+      - "length"
+      - "size"
     And:
       - "&&"
       - "and"


### PR DESCRIPTION
# :dart: Goal

To add `Size` operator support to Ruby.

# :beetle: Fixes

Fixes https://github.com/mumuki/mulang/issues/323