### PR TITLE
Fix #324 hash map inspection

### DIFF
--- a/gem/lib/mulang/expectation.rb
+++ b/gem/lib/mulang/expectation.rb
@@ -72,7 +72,7 @@ module Mulang::Expectation
   def self.guess_type(expectation)
     if expectation[:binding] == '<<custom>>'
       Custom
-    elsif expectation[:inspection] =~ /(Not\:)?Has.*/ && !has_smell?(expectation[:inspection])
+    elsif expectation[:inspection] =~ /^(Not\:)?Has.*/ && !has_smell?(expectation[:inspection])
       V0
     else
       V2

--- a/gem/spec/format_spec.rb
+++ b/gem/spec/format_spec.rb
@@ -31,6 +31,10 @@ describe Mulang::Expectation do
 
     it { expect(subject.guess_type binding: 'foo', inspection: 'HasEmptyRepeat').to be Mulang::Expectation::V2 }
     it { expect(subject.guess_type binding: 'foo', inspection: 'HasRedundantBooleanComparison').to be Mulang::Expectation::V2 }
+
+    context 'when inspections have dangling `Has`' do
+      it { expect(subject.guess_type binding: 'foo', inspection: 'Instantiates:HashMap').to be Mulang::Expectation::V2 }
+    end
   end
 
   describe 'it can convert back to hash' do
@@ -111,7 +115,15 @@ describe Mulang::Expectation do
           .to json_like binding: 'foo', inspection: {type: 'UsesWhile', negated: false}   }
 
     it { expect(subject.parse(binding: 'foo', inspection: 'HasUsage:bar').as_v2)
-          .to json_like binding: 'foo', inspection: {type: 'Uses', target: {type: :named, value: 'bar'}, negated: false}   }
+          .to json_like binding: 'foo', inspection: {type: 'Uses', target: {type: :named, value: 'bar'}, negated: false} }
+
+    context 'when inspections have dangling `Has`' do
+      it { expect(subject.parse(binding: '*', inspection: 'UsesHash').as_v2)
+            .to json_like binding: '*', inspection: {type: 'UsesHash', negated: false }  }
+
+      it { expect(subject.parse(binding: '*', inspection: 'Instantiates:HashMap').as_v2)
+            .to json_like binding: '*', inspection: {type: 'Instantiates', target: {type: :unknown, value: 'HashMap'}, negated: false } }
+    end
 
   end
 end

--- a/spec/ObjectOrientedSpec.hs
+++ b/spec/ObjectOrientedSpec.hs
@@ -26,6 +26,14 @@ spec = do
     it "is False when not instantiates" $ do
       instantiates (named "Bird") (java "class Main {  void main(String[] args) { Animal a = new Mammal(); }  }") `shouldBe` False
 
+    it "is True when instantiates a HashSet" $ do
+      instantiates (named "TreeSet") (java "class Main {  private Set<String> aSet = new TreeSet<>(); }") `shouldBe` True
+      instantiates (named "HashSet") (java "class Main {  private Set<String> aSet = new TreeSet<>(); }") `shouldBe` False
+
+    it "is False when not instantiates a HashSet" $ do
+      instantiates (named "TreeSet") (java "class Main {  private Set<String> aSet = new HashSet<>(); }") `shouldBe` False
+      instantiates (named "HashSet") (java "class Main {  private Set<String> aSet = new HashSet<>(); }") `shouldBe` True
+
   describe "implements" $ do
     it "is True when implements" $ do
       implements (named "Bird") (java "class Eagle implements Bird {}") `shouldBe` True


### PR DESCRIPTION
# :dart: Goal

To fix parsing of expectations when they contain the sequence `Has` in places different than the start. 

# :memo: Details

_How much damage can a single ^ do?_ :facepalm: 

