### PR TITLE
Fix external languages fixes

### DIFF
--- a/gem/lib/mulang/code.rb
+++ b/gem/lib/mulang/code.rb
@@ -30,8 +30,8 @@ module Mulang
       @language.sample @content
     end
 
-    def analysis(spec)
-      { sample: sample, spec: spec }
+    def analysis(spec, **options)
+      @language.build_analysis @content, spec, **options
     end
 
     def analyse(spec, **options)

--- a/gem/lib/mulang/language.rb
+++ b/gem/lib/mulang/language.rb
@@ -1,4 +1,18 @@
 module Mulang::Language
+  CORE_LANGUAGES = %w(
+    Java
+    JavaScript
+    Prolog
+    Haskell
+    Python
+    Python2
+    Python3
+    Ruby
+    Php
+    C
+    Mulang
+  )
+
   class Base
     def identifiers(content, **options)
       Mulang.analyse(identifiers_analysis(content, **options), **options)['outputIdentifiers'] rescue nil
@@ -55,6 +69,10 @@ module Mulang::Language
         content: content
       }
     end
+
+    def core_name
+      @name
+    end
   end
 
   class External < Base
@@ -81,7 +99,11 @@ module Mulang::Language
     end
 
     def build_analysis(*)
-      super.deep_merge(spec: {originalLanguage: @name}.compact)
+      super.deep_merge(spec: {originalLanguage: core_name}.compact)
+    end
+
+    def core_name
+      @name.in?(CORE_LANGUAGES) ? name : nil
     end
 
     private

--- a/gem/lib/mulang/language.rb
+++ b/gem/lib/mulang/language.rb
@@ -5,7 +5,7 @@ module Mulang::Language
     end
 
     def identifiers_analysis(content, **options)
-      base_analysis content, {includeOutputIdentifiers: true}, **options
+      build_analysis content, {includeOutputIdentifiers: true}, **options
     end
 
     def transformed_asts(content, operations, **options)
@@ -13,7 +13,7 @@ module Mulang::Language
     end
 
     def transformed_asts_analysis(content, operations, **options)
-      base_analysis content, {transformationSpecs: operations}, **options
+      build_analysis content, {transformationSpecs: operations}, **options
     end
 
     def normalization_options(**options)
@@ -25,12 +25,10 @@ module Mulang::Language
     end
 
     def ast_analysis(content, **options)
-      base_analysis content, {includeOutputAst: true}, **options
+      build_analysis content, {includeOutputAst: true}, **options
     end
 
-    private
-
-    def base_analysis(content, spec, **options)
+    def build_analysis(content, spec, **options)
       {
         sample: sample(content),
         spec: {
@@ -82,7 +80,7 @@ module Mulang::Language
       }
     end
 
-    def base_analysis(*)
+    def build_analysis(*)
       super.deep_merge(spec: {originalLanguage: @name}.compact)
     end
 

--- a/gem/lib/mulang/language.rb
+++ b/gem/lib/mulang/language.rb
@@ -76,7 +76,7 @@ module Mulang::Language
     def sample(content)
       {
         tag: 'MulangSample',
-        ast: call_tool(content) || {tag: :None}
+        ast: call_tool(content)
       }
     end
 

--- a/gem/lib/mulang/language.rb
+++ b/gem/lib/mulang/language.rb
@@ -76,7 +76,7 @@ module Mulang::Language
     def sample(content)
       {
         tag: 'MulangSample',
-        ast: call_tool(content)
+        ast: call_tool(content) || {tag: :None}
       }
     end
 

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -207,20 +207,33 @@ describe Mulang::Code do
   end
   describe 'original language' do
     let(:ast) { {:tag=>:Method, :contents=>[:drive!, [[[], {:tag=>:UnguardedBody, :contents=>{:tag=>:MuNil}}]]]} }
-    context 'when language is external with original language name' do
+    let(:bracket_ast) { '[Method[drive!][Equation[UnguardedBody[MuNil]]]]' }
+
+    context 'when language is external with original, core language name' do
       let(:code) { Mulang::Code.external('Ruby', ast) }
       it { expect(code.language.name).to eq 'Ruby' }
+      it { expect(code.language.core_name).to eq 'Ruby' }
       it { expect(code.ast_analysis[:spec][:originalLanguage]).to eq 'Ruby' }
       it { expect(code.analyse(smellsSet: {tag: :NoSmells, include: ['HasWrongCaseIdentifiers']})['smells']).to eq [] }
-      it { expect(code.ast serialization: :bracket).to eq '[Method[drive!][Equation[UnguardedBody[MuNil]]]]' }
+      it { expect(code.ast serialization: :bracket).to eq bracket_ast }
+    end
+
+    context 'when language is external with original, non-core language name' do
+      let(:code) { Mulang::Code.external('C#', ast) }
+      it { expect(code.language.name).to eq 'C#' }
+      it { expect(code.language.core_name).to be nil }
+      it { expect(code.ast_analysis[:spec][:originalLanguage]).to be nil }
+      it { expect(code.analyse(smellsSet: {tag: :NoSmells, include: ['HasWrongCaseIdentifiers']})['smells']).to eq [{"binding"=>"drive!", "inspection"=>"HasWrongCaseIdentifiers"}] }
+      it { expect(code.ast serialization: :bracket).to eq bracket_ast }
     end
 
     context 'when language is external with no original language name' do
       let(:code) { Mulang::Code.external(ast) }
       it { expect(code.language.name).to be nil }
+      it { expect(code.language.core_name).to be nil }
       it { expect(code.ast_analysis[:spec][:originalLanguage]).to be nil }
       it { expect(code.analyse(smellsSet: {tag: :NoSmells, include: ['HasWrongCaseIdentifiers']})['smells']).to eq [{"binding"=>"drive!", "inspection"=>"HasWrongCaseIdentifiers"}] }
-      it { expect(code.ast serialization: :bracket).to eq '[Method[drive!][Equation[UnguardedBody[MuNil]]]]' }
+      it { expect(code.ast serialization: :bracket).to eq bracket_ast }
     end
   end
 

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -126,30 +126,18 @@ describe Mulang::Code do
       let(:ast) { nil }
 
       it { expect(code.ast).to be nil }
-      it { expect(code.sample).to eq :ast=>{tag: :None}, :tag=>"MulangSample" }
-      it { expect(code.analyse(expectations: [])).to eq 'tag'=>'AnalysisCompleted',
-                                                        'outputAst'=>nil,
-                                                        'outputIdentifiers' => nil,
-                                                        'transformedAsts' => nil,
-                                                        'signatures'=>[],
-                                                        'smells'=>[],
-                                                        'expectationResults'=>[],
-                                                        'testResults' => [] }
+      it { expect(code.sample).to eq :ast=>nil, :tag=>"MulangSample" }
+      it { expect(code.analyse(expectations: [])).to eq 'tag'=>'AnalysisFailed',
+                                                        'reason'=>'missing AST' }
     end
 
     context "when tool fails" do
       let(:code) { Mulang::Code.external("foo") { raise "ups" } }
 
       it { expect(code.ast).to be nil }
-      it { expect(code.sample).to eq :ast=>{tag: :None}, :tag=>"MulangSample" }
-      it { expect(code.analyse(expectations: [])).to eq 'tag'=>'AnalysisCompleted',
-                                                        'outputAst'=>nil,
-                                                        'outputIdentifiers' => nil,
-                                                        'transformedAsts' => nil,
-                                                        'signatures'=>[],
-                                                        'smells'=>[],
-                                                        'expectationResults'=>[],
-                                                        'testResults' => [] }
+      it { expect(code.sample).to eq :ast=>nil, :tag=>"MulangSample" }
+      it { expect(code.analyse(expectations: [])).to eq 'tag'=>'AnalysisFailed',
+                                                        'reason'=>'missing AST' }
     end
 
   end

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -105,10 +105,53 @@ describe Mulang::Code do
   end
 
   context 'when code is expressed as an ast' do
-    let(:ast) { {'tag'=>'Variable', 'contents'=>['x', {'tag'=>'MuNumber', 'contents'=>1}]} }
     let(:code) { Mulang::Code.external(ast) }
 
-    it { expect(code.ast).to eq ast }
+    context "when ast is valid" do
+      let(:ast) { {'tag'=>'Variable', 'contents'=>['x', {'tag'=>'MuNumber', 'contents'=>1}]} }
+
+      it { expect(code.ast).to eq ast }
+      it { expect(code.sample).to eq :ast=>ast, :tag=>"MulangSample" }
+      it { expect(code.analyse(expectations: [])).to eq 'tag'=>'AnalysisCompleted',
+                                                        'outputAst'=>nil,
+                                                        'outputIdentifiers' => nil,
+                                                        'transformedAsts' => nil,
+                                                        'signatures'=>[],
+                                                        'smells'=>[],
+                                                        'expectationResults'=>[],
+                                                        'testResults' => [] }
+    end
+
+    context "when ast is nil" do
+      let(:ast) { nil }
+
+      it { expect(code.ast).to be nil }
+      it { expect(code.sample).to eq :ast=>{tag: :None}, :tag=>"MulangSample" }
+      it { expect(code.analyse(expectations: [])).to eq 'tag'=>'AnalysisCompleted',
+                                                        'outputAst'=>nil,
+                                                        'outputIdentifiers' => nil,
+                                                        'transformedAsts' => nil,
+                                                        'signatures'=>[],
+                                                        'smells'=>[],
+                                                        'expectationResults'=>[],
+                                                        'testResults' => [] }
+    end
+
+    context "when tool fails" do
+      let(:code) { Mulang::Code.external("foo") { raise "ups" } }
+
+      it { expect(code.ast).to be nil }
+      it { expect(code.sample).to eq :ast=>{tag: :None}, :tag=>"MulangSample" }
+      it { expect(code.analyse(expectations: [])).to eq 'tag'=>'AnalysisCompleted',
+                                                        'outputAst'=>nil,
+                                                        'outputIdentifiers' => nil,
+                                                        'transformedAsts' => nil,
+                                                        'signatures'=>[],
+                                                        'smells'=>[],
+                                                        'expectationResults'=>[],
+                                                        'testResults' => [] }
+    end
+
   end
 
   context 'when code is ill-formed' do

--- a/gem/spec/mulang_spec.rb
+++ b/gem/spec/mulang_spec.rb
@@ -174,19 +174,23 @@ describe Mulang::Code do
 
     end
   end
+  describe 'original language' do
+    let(:ast) { {:tag=>:Method, :contents=>[:drive!, [[[], {:tag=>:UnguardedBody, :contents=>{:tag=>:MuNil}}]]]} }
+    context 'when language is external with original language name' do
+      let(:code) { Mulang::Code.external('Ruby', ast) }
+      it { expect(code.language.name).to eq 'Ruby' }
+      it { expect(code.ast_analysis[:spec][:originalLanguage]).to eq 'Ruby' }
+      it { expect(code.analyse(smellsSet: {tag: :NoSmells, include: ['HasWrongCaseIdentifiers']})['smells']).to eq [] }
+      it { expect(code.ast serialization: :bracket).to eq '[Method[drive!][Equation[UnguardedBody[MuNil]]]]' }
+    end
 
-  context 'when language is external with original language name' do
-    let(:code) { Mulang::Code.external('Ruby', tag: :None) }
-    it { expect(code.language.name).to eq 'Ruby' }
-    it { expect(code.ast_analysis[:spec][:originalLanguage]).to eq 'Ruby' }
-    it { expect(code.ast serialization: :bracket).to eq '[None]' }
-  end
-
-  context 'when language is external with no original language name' do
-    let(:code) { Mulang::Code.external(tag: :None) }
-    it { expect(code.language.name).to be nil }
-    it { expect(code.ast_analysis[:spec][:originalLanguage]).to be nil }
-    it { expect(code.ast serialization: :bracket).to eq '[None]' }
+    context 'when language is external with no original language name' do
+      let(:code) { Mulang::Code.external(ast) }
+      it { expect(code.language.name).to be nil }
+      it { expect(code.ast_analysis[:spec][:originalLanguage]).to be nil }
+      it { expect(code.analyse(smellsSet: {tag: :NoSmells, include: ['HasWrongCaseIdentifiers']})['smells']).to eq [{"binding"=>"drive!", "inspection"=>"HasWrongCaseIdentifiers"}] }
+      it { expect(code.ast serialization: :bracket).to eq '[Method[drive!][Equation[UnguardedBody[MuNil]]]]' }
+    end
   end
 
   context 'when language is native with normalization options' do

--- a/spec/AnalysisJsonSpec.hs
+++ b/spec/AnalysisJsonSpec.hs
@@ -171,7 +171,7 @@ spec = describe "AnalysisJson" $ do
       }
    }
 }|]
-    let analysis = Analysis (MulangSample (Sequence [Variable "x" (MuNumber 1), Variable "y" (MuNumber 2)]))
+    let analysis = Analysis (MulangSample (Just (Sequence [Variable "x" (MuNumber 1), Variable "y" (MuNumber 2)])))
                             (emptyAnalysisSpec { signatureAnalysisType = Just (StyledSignatures HaskellStyle) })
 
     run json `shouldBe` analysis
@@ -331,8 +331,8 @@ spec = describe "AnalysisJson" $ do
     "includeOutputAst": true
   }
 } |]
-    let analysis = Analysis (MulangSample (SimpleProcedure "foo" [VariablePattern "x"]
-                                              (Application (Primitive Multiply) [MuNumber 2.0,Reference "x"])))
+    let analysis = Analysis (MulangSample (Just (SimpleProcedure "foo" [VariablePattern "x"]
+                                              (Application (Primitive Multiply) [MuNumber 2.0,Reference "x"]))))
                             (emptyAnalysisSpec {
                               normalizationOptions = Just (unnormalized {
                                 insertImplicitReturn = True

--- a/spec/AutocorrectorSpec.hs
+++ b/spec/AutocorrectorSpec.hs
@@ -18,13 +18,13 @@ spec :: Spec
 spec = do
   describe "correct custom usages" $ do
     it "corrects given rules when using MulangSample and originalLanguage" $ do
-      let setting = runWithCustomRules (Just Ruby) (MulangSample None) [("Uses:foo", "UsesPlus")]
+      let setting = runWithCustomRules (Just Ruby) (MulangSample (Just None)) [("Uses:foo", "UsesPlus")]
 
       setting (Expectation "*" "UsesPlus")  `shouldBe` (Expectation "*" "UsesPlus")
       setting (Expectation "*" "Uses:foo")  `shouldBe` (Expectation "*" "UsesPlus")
 
     it "corrects given rules when using MulangSample and no originalLanguage" $ do
-      let setting = runWithCustomRules Nothing (MulangSample None) [("Uses:foo", "UsesPlus")]
+      let setting = runWithCustomRules Nothing (MulangSample (Just None)) [("Uses:foo", "UsesPlus")]
 
       setting (Expectation "*" "UsesPlus")  `shouldBe` (Expectation "*" "UsesPlus")
       setting (Expectation "*" "Uses:foo")  `shouldBe` (Expectation "*" "UsesPlus")

--- a/spec/ExpectationsAnalyzerSpec.hs
+++ b/spec/ExpectationsAnalyzerSpec.hs
@@ -8,7 +8,7 @@ result expectationResults smells
   = emptyCompletedAnalysisResult { expectationResults = expectationResults, smells = smells }
 
 run language content expectations = analyse (expectationsAnalysis (CodeSample language content) expectations)
-runAst ast expectations = analyse (expectationsAnalysis (MulangSample ast) expectations)
+runAst ast expectations = analyse (expectationsAnalysis (MulangSample (Just ast)) expectations)
 
 passed e = ExpectationResult e True
 failed e = ExpectationResult e False

--- a/spec/SmellsAnalyzerSpec.hs
+++ b/spec/SmellsAnalyzerSpec.hs
@@ -74,7 +74,7 @@ spec = describe "SmellsAnalyzer" $ do
         runWithTypos JavaScript "function bar() {}\nfunction other(){}" [Expectation "*" "SubordinatesDeclarationsTo:bar"] `shouldReturn` []
 
   it "Using domain language and nested structures" $ do
-    let runRuby sample = analyse (domainLanguageAnalysis (MulangSample sample) (DomainLanguage Nothing (Just RubyCase) (Just 3) Nothing))
+    let runRuby sample = analyse (domainLanguageAnalysis (MulangSample (Just sample)) (DomainLanguage Nothing (Just RubyCase) (Just 3) Nothing))
     (runRuby (Sequence [
       (Object "Foo_Bar" (Sequence [
         (SimpleMethod "y" [] None),

--- a/src/Language/Mulang/Analyzer/Analysis.hs
+++ b/src/Language/Mulang/Analyzer/Analysis.hs
@@ -120,7 +120,7 @@ data SignatureStyle
   | PrologStyle deriving (Show, Eq, Generic)
 
 data Fragment
-  = MulangSample { ast :: Expression }
+  = MulangSample { ast :: Maybe Expression }
   | CodeSample { language :: Language, content :: Code } deriving (Show, Eq, Generic)
 
 data InterpreterOptions = InterpreterOptions {

--- a/src/Language/Mulang/Analyzer/FragmentParser.hs
+++ b/src/Language/Mulang/Analyzer/FragmentParser.hs
@@ -22,7 +22,8 @@ parseFragment :: Maybe NormalizationOptions -> Fragment -> Either String Express
 parseFragment options = fmap (normalizerFor options) . parse
   where
     parse (CodeSample language content) = (parserFor language) content
-    parse (MulangSample ast)            = Right ast
+    parse (MulangSample (Just ast))     = Right ast
+    parse (MulangSample Nothing)        = Left "missing AST"
 
 parserFor :: Language -> EitherParser
 parserFor C              = parseC


### PR DESCRIPTION
# :dart: Goal

To fix issues related with the ruby interface:

* original language of external languages was not used in the `analyse` and `analysis` methods
* passing `nil` ast the ast produced severe parsing errors at mulang core. This a big pain in the neck when using the batch mode and the external tool can not parse the source code. 
    