### PR TITLE
Replacing ghcjslib's version at release time

### DIFF
--- a/ghcjslib/release.sh
+++ b/ghcjslib/release.sh
@@ -15,6 +15,9 @@ echo "[Mulang::Ghcjslib] Building mulang with GHCJS..."
 mkdir -p .deploy/build
 cp LICENSE ghcjslib/README.md ghcjslib/package.json .deploy/
 cp ghcjslib/index.js .deploy/mulang-cli.js
+
+VERSION=$(sed -nr 's/^\s*\"version": "([0-9]{1,}\.[0-9]{1,}.*)"$/\1/p' package.json)
+sed -i "0,/require('..\/package.json').version/s//$VERSION/" ghcjslib/build/mulang.js
 cp ghcjslib/build/mulang.js .deploy/build/mulang.js
 
 echo "[Mulang::Ghcjslib] Publishing package to npm..."

--- a/ghcjslib/src/main.js
+++ b/ghcjslib/src/main.js
@@ -29,5 +29,6 @@ ghcjsExports.astCode = function(ast) {
 };
 
 if (typeof require != 'undefined') {
+  // Will get overriden at release time (see release.sh)
   ghcjsExports.version = require('../package.json').version;
 }


### PR DESCRIPTION
La siguiente línea está trayendo problemas para proyectos donde se importe mulang.js directamente sin estar dentro de una carpeta, porque no encuentra el package.json:

https://github.com/mumuki/mulang/blob/6c04e3e1816eed8925e1bb152b8ac9c03608b02e/ghcjslib/src/main.js#L31-L33

Propuse reemplazarla en release time, no sé cómo resolverlo de otra forma.