### PR TITLE
Feature parse keyword arguments

### DIFF
--- a/docs/astspec.md
+++ b/docs/astspec.md
@@ -1220,6 +1220,16 @@ function foo(x, y) { }
 (UnionPattern [Pattern])
 ```
 
+### `DefaultPattern`
+
+Pattern for patterns with a default value when no matching is produced, like for example optional arguments.
+
+#### Syntax
+
+```haskell
+(DefaultPattern Pattern Expression)
+```
+
 ### `OtherPattern`
 
 > Other unrecognized pattern

--- a/spec/GenericSpec.hs
+++ b/spec/GenericSpec.hs
@@ -269,14 +269,22 @@ spec = do
       usesLogic (hs "f x y = or x")  `shouldBe` False
 
   describe "usesMath" $ do
-    it "is when it is used in function bodies" $ do
+    it "is True when it is used in function bodies" $ do
       usesMath (hs "f x y = x + y")    `shouldBe` True
       usesMath (hs "f x y = x * y")    `shouldBe` True
       usesMath (hs "f x y = x / x")    `shouldBe` True
       usesMath (hs "f x y = div x z")  `shouldBe` True
       usesMath (hs "f x y = x - y")    `shouldBe` True
 
-    it "is when it is used in composite literals" $ do
+    it "is True when it is used in named arguments" $ do
+      usesMath (py3 "f(x = 4 + 5)")     `shouldBe` True
+      usesMath (py3 "f(x = 4)")         `shouldBe` False
+
+    it "is True when it is used in default parameters" $ do
+      usesMath (py3 "def f(x = 4 + 5): pass") `shouldBe` True
+      usesMath (py3 "def f(x = 4): pass")      `shouldBe` False
+
+    it "is True when it is used in composite literals" $ do
       usesMath (py3 "{'hello': 4 + 5}") `shouldBe` True
       usesMath (py3 "{'hello': 4}")     `shouldBe` False
 
@@ -286,7 +294,7 @@ spec = do
       usesMath (js "[4+5, 0]")          `shouldBe` True
       usesMath (js "[9, 0]")            `shouldBe` False
 
-    it "is is not used otherwise" $ do
+    it "is True is not used otherwise" $ do
       usesMath (hs "f x y = x")       `shouldBe` False
       usesMath (hs "f x y = plus x")  `shouldBe` False
       usesMath (hs "f x y = minus x") `shouldBe` False

--- a/spec/PythonSpec.hs
+++ b/spec/PythonSpec.hs
@@ -53,6 +53,9 @@ spec = do
     it "parses assignment" $ do
       py "one = 1" `shouldBe` Assignment "one" (MuNumber 1.0)
 
+    it "parses arg keywords" $ do
+      py "f(x=1)" `shouldBe` Application (Reference "f") [As "x" (MuNumber 1.0)]
+
     it "allows parentheses" $ do
       py "(123)" `shouldBe` MuNumber 123
 

--- a/spec/PythonSpec.hs
+++ b/spec/PythonSpec.hs
@@ -117,6 +117,11 @@ spec = do
     it "parses functions" $ do
       py "def foo(): return 1" `shouldBe` SimpleFunction "foo" [] (Return (MuNumber 1.0))
 
+    it "parses functions with optional args" $ do
+      py "def foo(x=1): return x" `shouldBe` Function "foo" [
+          Equation [DefaultPattern (VariablePattern "x") (MuNumber 1)] (UnguardedBody (Return (Reference "x")))
+        ]
+
     it "parses print" $ do
       py "print()" `shouldBe` (Print None)
       py "print(x)" `shouldBe` (Print (Reference "x"))

--- a/src/Language/Mulang/Ast.hs
+++ b/src/Language/Mulang/Ast.hs
@@ -81,7 +81,7 @@ data Type
         -- Useful for modelling functions, methods and procedures types
         | ConstrainedType [Identifier]
         -- ^ constrained type, with just type constraints.
-        -- Usefull for modelling classes and interfaces types
+        -- Useful for modelling classes and interfaces types
         | OtherType (Maybe Code) (Maybe Type)
         -- ^ unrecognized type, with optional code and nested type
         deriving (Eq, Show, Read, Generic, Ord)
@@ -125,6 +125,8 @@ data Expression
     -- ^ Imperative programming procedure declaration. It is composed by a name and one or more equations
     | Method Identifier SubroutineBody
     | PrimitiveMethod Operator SubroutineBody
+    | As Identifier Expression
+    -- ^ Unstable API, subject to change
     | Variable Identifier Expression
     | Constant Identifier Expression
     | Assignment Identifier Expression
@@ -150,24 +152,25 @@ data Expression
     | Fact Identifier [Pattern]
     -- ^ Logic programming declaration of a fact , composed by the fact name and fact arguments
     | Exist Identifier [Pattern]
-    -- ^ Logic programming existential cuantification / consult
+    -- ^ Logic programming existential quantification / consult
     | Not Expression
     -- ^ Logic programming negation
     | Findall Expression Expression Expression
     -- ^ Logic programming findall
     | Forall Expression Expression
-    -- ^ Logic programming universal cuantification
+    -- ^ Logic programming universal quantification
     | Reference Identifier
     -- ^ Generic variable
     | FieldReference Expression Identifier
     -- ^ Generic nested field access
     | Primitive Operator
-    -- ^ Reference to special, low level, universal operations like logical operaions and math, that may or may not be primitives
+    -- ^ Reference to special, low level, universal operations like logical operations and math, that may or may not be primitives
     -- in the original language
     | Application Expression [Expression]
-    -- ^ Generic, non-curried application of a function or procedure, composed by the applied element itself, and the application arguments
+    -- ^ Generic, non-curried application of a function or procedure, composed by the applied element itself,
+    -- and the application arguments
     | Send Expression Expression [Expression]
-    -- ^ Object oriented programming message send, composed by the reciever, selector and arguments
+    -- ^ Object oriented programming message send, composed by the receiver, selector and arguments
     | New Expression [Expression]
     -- ^ Object oriented instantiation, composed by the class reference and instantiation arguments
     | Implement Expression
@@ -192,9 +195,9 @@ data Expression
     | Continue Expression
     -- ^ Imperative programming step skip statement
     | Try Expression [(Pattern, Expression)] Expression
-    -- ^ Generic try expression, composed by a body, a list of exception-handling patterns and statments, and a finally expression
+    -- ^ Generic try expression, composed by a body, a list of exception-handling patterns and statements, and a finally expression
     | Raise Expression
-    -- ^ Generic raise expression, like a throw or raise statament, composed by the raised expression
+    -- ^ Generic raise expression, like a throw or raise statement, composed by the raised expression
     | Print Expression
     -- ^ Generic print expression
     | For [Statement] Expression

--- a/src/Language/Mulang/Ast.hs
+++ b/src/Language/Mulang/Ast.hs
@@ -276,6 +276,9 @@ data Pattern
     | WildcardPattern
     -- ^ wildcard pattern @_@
     | UnionPattern [Pattern]
+    | DefaultPattern Pattern Expression
+    -- ^ Pattern for patterns with a default value when no matching is produced,
+    -- like for example optional arguments
     | OtherPattern (Maybe Code) (Maybe Pattern)
     -- ^ Other unrecognized pattern with optional code and nested pattern
   deriving (Eq, Show, Read, Generic, Ord)
@@ -353,8 +356,9 @@ extractLValue (Constant name value) = Just (name, value)
 extractLValue _                     = Nothing
 
 extractLValuePattern :: Pattern -> Maybe Identifier
-extractLValuePattern (VariablePattern name) = Just name
 extractLValuePattern (ConstantPattern name) = Just name
+extractLValuePattern (VariablePattern name) = Just name
+extractLValuePattern (DefaultPattern p _)   = extractLValuePattern p
 extractLValuePattern _                      = Nothing
 
 extractUnification :: Expression -> Maybe (Identifier, Expression)

--- a/src/Language/Mulang/Ast/Visitor.hs
+++ b/src/Language/Mulang/Ast/Visitor.hs
@@ -61,6 +61,7 @@ extractTerminal _                   = False
 pattern SingleExpression e1 c <- (extractSingleExpression -> Just (e1, c))
 
 extractSingleExpression :: Expression -> Maybe (Expression, Expression -> Expression)
+extractSingleExpression (As n e)                 = Just (e, \e -> (As n e))
 extractSingleExpression (Assignment v1 e)        = Just (e, \e -> (Assignment v1 e))
 extractSingleExpression (Attribute v1 e)         = Just (e, \e -> (Attribute v1 e))
 extractSingleExpression (Break e)                = Just (e, \e -> (Break e))

--- a/src/Language/Mulang/Generator.hs
+++ b/src/Language/Mulang/Generator.hs
@@ -149,10 +149,14 @@ extractReference (Exist n _)          = Just n
 extractReference _                    = Nothing
 
 equationsExpressions :: [Equation] -> [Expression]
-equationsExpressions = concatMap (\(Equation _ body) -> bodyExpressions body)
+equationsExpressions = concatMap (\(Equation params body) -> paramsExpression params ++ bodyExpressions body)
   where
     bodyExpressions (UnguardedBody e)      = [e]
     bodyExpressions (GuardedBody b)        = b >>= \(es1, es2) -> [es1, es2]
+
+    paramsExpression ((DefaultPattern _ e):ps) = e:paramsExpression ps
+    paramsExpression (_:ps)                    = paramsExpression ps
+    paramsExpression _                         = []
 
 statementsExpressions :: [Statement] -> [Expression]
 statementsExpressions = map expression

--- a/src/Language/Mulang/Inspector/Functional.hs
+++ b/src/Language/Mulang/Inspector/Functional.hs
@@ -39,8 +39,9 @@ usesPatternMatching = containsExpression f
         patterns = concatMap (\(Equation ps _) -> ps)
 
         nonVariablePattern :: Pattern -> Bool
-        nonVariablePattern (VariablePattern _) = False
-        nonVariablePattern _                   = True
+        nonVariablePattern (VariablePattern _)  = False
+        nonVariablePattern (DefaultPattern p _) = nonVariablePattern p
+        nonVariablePattern _                    = True
 
 
 -- | Inspection that tells whether an expression uses

--- a/src/Language/Mulang/Inspector/Primitive.hs
+++ b/src/Language/Mulang/Inspector/Primitive.hs
@@ -34,6 +34,7 @@ containsDeclaration f = has f declarations
 matchesType :: IdentifierPredicate -> Pattern -> Bool
 matchesType predicate (TypePattern n)               = predicate n
 matchesType predicate (AsPattern _ (TypePattern n)) = predicate n
+matchesType predicate (DefaultPattern pattern _)    = matchesType predicate pattern
 matchesType predicate (UnionPattern patterns)       = any (matchesType predicate) patterns
 matchesType _         _                             = False
 

--- a/src/Language/Mulang/Inspector/Smell.hs
+++ b/src/Language/Mulang/Inspector/Smell.hs
@@ -217,9 +217,10 @@ hasUnreachableCode = containsExpression f
 
         equationMatchesAnyValue (Equation patterns body) = all patternMatchesAnyValue patterns && bodyMatchesAnyValue body
 
-        patternMatchesAnyValue WildcardPattern     = True
-        patternMatchesAnyValue (VariablePattern _) = True
-        patternMatchesAnyValue _                   = False
+        patternMatchesAnyValue WildcardPattern      = True
+        patternMatchesAnyValue (VariablePattern _)  = True
+        patternMatchesAnyValue (DefaultPattern p _) = patternMatchesAnyValue p
+        patternMatchesAnyValue _                    = False
 
         bodyMatchesAnyValue (UnguardedBody _)    = True
         bodyMatchesAnyValue (GuardedBody guards) = any (isTruthy . fst) guards

--- a/src/Language/Mulang/Parsers/Python.hs
+++ b/src/Language/Mulang/Parsers/Python.hs
@@ -124,7 +124,8 @@ containsReturn (M.Sequence xs) = any containsReturn xs
 containsReturn _               = False
 
 muParameter :: ParameterSpan -> M.Pattern
-muParameter (Param name _ _ _) = M.VariablePattern (muIdent name)
+muParameter (Param name _ Nothing _)  = muVariablePattern name
+muParameter (Param name _ (Just e) _) = M.DefaultPattern (muVariablePattern name) (muExpr e)
 
 muIdent :: IdentSpan -> String
 muIdent (Ident id _) = id
@@ -202,10 +203,12 @@ muPatterns [pattern]      = muPattern pattern
 muPatterns patterns@(_:_) = M.TuplePattern . map muPattern $ patterns
 
 muPattern :: ExprSpan -> M.Pattern
-muPattern (Var ident _) = M.VariablePattern . muIdent $ ident
+muPattern (Var ident _) = muVariablePattern ident
 muPattern (Tuple es _)  = M.TuplePattern . map muPattern $ es
 muPattern (Paren e  _)  = muPattern e
 muPattern other         = M.debugPattern other
+
+muVariablePattern = M.VariablePattern . muIdent
 
 muList = M.MuList . map muExpr
 

--- a/src/Language/Mulang/Parsers/Python.hs
+++ b/src/Language/Mulang/Parsers/Python.hs
@@ -245,11 +245,7 @@ muAssignment other                   = const (M.debug other)
 muArgument (ArgExpr expr _)             = muExpr expr
 muArgument (ArgVarArgsPos expr _ )      = muExpr expr
 muArgument (ArgVarArgsKeyword expr _ )  = muExpr expr
---muArgument ArgKeyword
---     { arg_keyword :: Ident annot -- ^ Keyword name.
---     , arg_expr :: Expr annot -- ^ Argument expression.
---     , arg_annot :: annot
---     }
+muArgument (ArgKeyword name expr _)     = M.As (muIdent name) (muExpr expr)
 muArgument e                            = M.debug e
 
 --muYieldArg (YieldFrom expr _)(Expr annot) annot -- ^ Yield from a generator (Version 3 only)

--- a/src/Language/Mulang/Signature.hs
+++ b/src/Language/Mulang/Signature.hs
@@ -67,8 +67,9 @@ parameterNamesOf :: [Equation] -> [Maybe Identifier]
 parameterNamesOf = map msum . transpose . map (map parameterNameOf . equationPatterns)
 
 parameterNameOf :: Pattern -> Maybe Identifier
-parameterNameOf (VariablePattern v) = Just v
-parameterNameOf _                   = Nothing
+parameterNameOf (VariablePattern v)  = Just v
+parameterNameOf (DefaultPattern p _) = parameterNameOf p
+parameterNameOf _                    = Nothing
 
 codeSignaturesOf :: Expression -> [Code]
 codeSignaturesOf = styledCodeSignaturesOf mulangStyle

--- a/src/Language/Mulang/Transform/Renamer.hs
+++ b/src/Language/Mulang/Transform/Renamer.hs
@@ -69,8 +69,9 @@ renameEquation (Equation ps b) = do
   return $ Equation ps' b'
 
 renameParameter :: Pattern -> RenameState Pattern
-renameParameter (VariablePattern n) = fmap VariablePattern . createParameter $ n
-renameParameter e                   = return e
+renameParameter (VariablePattern n)  = fmap VariablePattern . createParameter $ n
+renameParameter (DefaultPattern p e) = fmap (`DefaultPattern` e) $ renameParameter p
+renameParameter e                    = return e
 
 renameEquationBody (UnguardedBody e) = fmap UnguardedBody . renameState $ e
 renameEquationBody (GuardedBody es)  = fmap GuardedBody . mapM renameGuard $ es


### PR DESCRIPTION
# :dart: Goal

Add support for named arguments and parameters with default value

# :memo: Details

Two new AST elements have been added: `As` and `DefaultPattern`. Only the latter has been documented, since `As` may change in the near feature. Also, some typos have been fixed in the process. 


