### PR TITLE
Feature calls primitive

### DIFF
--- a/docs/edlspec.md
+++ b/docs/edlspec.md
@@ -205,15 +205,6 @@ expectation "`tell` must be called with value 10 and true":
 expectation "`play` must be called with this":
   %% equivalent to * Calls:play:WithSelf
   calls `play` with self;
-
-expectation "uses a repeat with a non-literal amount of iterations":
-  %% matches repeat blocks where the repeat count expression is a non-literal
-  %% and the loop body is anything
-  uses repeat with (nonliteral, anything);
-
-expectation "uses a repeat with a non-literal amount of iterations":
-  %% shorter version of previous example
-  uses repeat with nonliteral;
 ```
 
 Most of the matchers are designed to perform literal queries, but some of them allow more complex matching:
@@ -230,6 +221,18 @@ expectation "a method that performs boolean operations must be declared":
 expectation "`getAge` must not return a hardcoded value":
   %% equivalent to Intransitive:getAge Returns:WithNonliteral
   within `getAge` returns with nonliteral;
+
+expectation "uses a repeat with a non-literal amount of iterations":
+  %% matches repeat blocks where the repeat count expression is a non-literal
+  %% and the loop body is anything
+  uses repeat with (nonliteral, anything);
+
+expectation "uses a repeat with a non-literal amount of iterations":
+  %% shorter version of previous example
+  uses repeat with nonliteral;
+
+expectation "uses items[0] to get first item":
+  calls get at with (&`items`, 0);
 ```
 
 As you can see in previous examples, many of the simplest matchers can also be used in the standard expectation syntax. However, EDL also supports the `that` matcher,
@@ -333,10 +336,11 @@ This is the complete list of inspections that support matchers:
 ### Supported matchers
 
 * `(<matcher1>, <matcher2>.., <matcherN>)`: matches a tuple of expressions, like a callable's arguments or a control structure parts. If less elements than required are passed, the list is padded with `anything` matchers.
-* `<character>`: matches a single character
-* `<number>`: matches a number literal
-* `<string>`: matches a single string
-* `<symbol>`: matches a symbol literal
+* `'<character>'`: matches a single character - e.g. `'h'`
+* `<number>`: matches a number literal - e.g. `5` or `10.9`
+* `"<string>"`: matches a string literal - e.g. `"hello"`
+* `` `<symbol>` ``: matches a symbol literal - e.g. `` `id` ``
+* `` &`<identifier>` ``: matches a reference - e.g. `` &`counter` ``
 * `anything`: matches anything
 * `false` and `true`: matches the `true` and `false` literals
 * `literal`: matches any literal
@@ -428,7 +432,7 @@ expectation "pacakge `vet` must declare a class, enum or interface named `Pet`":
 expectation "`Pet` must declare `eat` and `Owner` must send it":
   %% however in most cases, it is better to declare two different, separate
   %% expectations
-  (within `Pet` declares `eat`) and (within `Owner` sends `eat`);
+  (within `Pet` declares `eat`) and (within `Owner` calls `eat`);
 ```
 
 # ⚠️ Caveats

--- a/docs/index.md
+++ b/docs/index.md
@@ -159,7 +159,13 @@ Finally, you can provide a _matcher_ to many of the available expectations, that
 > code.expect 'DeclaresAttribute:WithLiteral'
 => true # because weight is initialized with a literal value
 > code.expect 'DeclaresAttribute:WithNil'
-=> false # because no attribute is initialied with null
+=> false # because no attribute is initialized with null
+> code.expect 'DeclaresVariable:aPlace:WithReference:buenosAires'
+=> true # because the reference buenosAires is assigned to aPlace
+> code.expect 'DeclaresVariable:aBird:WithReference:aPlace'
+=> false # because the reference aPlace is NOT assigned to aBird...
+> code.expect 'aBird', 'Uses:aPlace'
+=> true # ...eventhough it is used
 ```
 
 The complete list of supported matchers is the following:
@@ -178,6 +184,29 @@ The complete list of supported matchers is the following:
   * `WithNumber:value`
   * `WithString:"value"`
 
+## Custom expectations
+
+Finally, Mulang support custom expectations, defined using the [EDL]((./edlspec)) language:
+
+```ruby
+> code = Mulang::Code.native "JavaScript", %q{
+  aBird['name'] = 'Norita';
+  aBird['energy'] = 100;
+  aBird.fly(rosario);
+}
+> code.custom_expect %q{
+  expectation "sets `aBird`'s name": calls set at with (&`aBird`, "name");
+  expectation "sets `'Pepita'` as `aBird`'s name": calls set at with (&`aBird`, "name", "Pepita");
+  expectation "assigns `100` to `aBird`'s energy ": calls set at with (&`aBird`, "energy", 100);
+  expectation "makes `aBird`'s fly to `rosario` ": calls `fly` with (&`aBird`, &`rosario`);
+}
+=> {
+ "sets `aBird`'s name"=>true,
+ "sets `'Pepita'` as `aBird`'s name"=>false,
+ "assigns `100` to `aBird`'s energy "=>true,
+ "makes `aBird`'s fly to `rosario` "=>true
+}
+```
 
 # Contributors
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -164,6 +164,7 @@ Finally, you can provide a _matcher_ to many of the available expectations, that
 
 The complete list of supported matchers is the following:
 
+  * `WithAnything`
   * `WithFalse`
   * `WithLiteral`
   * `WithLogic`
@@ -171,6 +172,7 @@ The complete list of supported matchers is the following:
   * `WithNil`
   * `WithNonliteral`
   * `WithTrue`
+  * `WithReference:value`
   * `WithChar:'value'`
   * `WithSymbol:value`
   * `WithNumber:value`

--- a/docs/inspections.md
+++ b/docs/inspections.md
@@ -74,57 +74,62 @@ The power of Mulang is grounded on more than 120 different kind of inspections
 > ⚠️ Please notice that the operators inspections are the preferred and most reliable way of checking
 > usage of language primitives. For example, prefer `UsesPlus` over `Uses:+`
 
-| Inspection                       | Meaning
-|----------------------------------|-----------------------
-| `UsesAbsolute`                   | is the numeric `abs`-like absolute operator used?
-| `UsesAllSatisfy`                 | is the collection `all`-like / `every`-like operator used?
-| `UsesAnd`                        | is the `&&`-like and operator used?
-| `UsesAnySatisfy`                 | is the collection `any`-like / `some`-like operator used?
-| `UsesBackwardComposition`        | is the `.`-like functional backward composition operator used?
-| `UsesBitwiseAnd`                 | is the bit-level `&`-like and operator used?
-| `UsesBitwiseLeftShift`           | is the bit-level left `<<`-like shift operator used?
-| `UsesBitwiseOr`                  | is the bit-level `|`-like or operator used?
-| `UsesBitwiseRightShift`          | is the bit-level right `>>`-like shift operator used?
-| `UsesBitwiseXor`                 | is the bit-level `^`-like xor operator used?
-| `UsesCeil`                       | is the numeric `ceil`-like ceiling operator used?
-| `UsesCollect`                    | is the collection `map`-like operator used?
-| `UsesCount`                      | is the collection `count`-like operator used?
-| `UsesDetect`                     | is the collection `find`-like search operator used?
-| `UsesDetectMax`                  | is the collection `max`-like maximum operator used?
-| `UsesDetectMin`                  | is the collection `min`-like minumum operator used?
-| `UsesDivide`                     | is the numeric `/` operator used?
-| `UsesEqual`                      | is the `===`-like equal operator used?
-| `UsesFlatten`                    | is the collection `flatten`-like operator used?
-| `UsesFloor`                      | is the numeric `ceil`-like floor operator used?
-| `UsesForwardComposition`         | is the `>>`-like functional forward composition operator used?
-| `UsesGather`                     | is the collection `flatmap`-like operator used?
-| `UsesGetAt`                      | is the collection `[]`-like operator used?
-| `UsesGreaterOrEqualThan`        | is the `>=` operator used?
-| `UsesGreaterThan`               | is the `>` operator used?
-| `UsesHash`                       | is the `hashcode` operator used?
-| `UsesInject`                     | is the collection `reduce`-like / `fold`-like operator used?
-| `UsesLessOrEqualThan`            | is the `<=` operator used?
-| `UsesLessThan`                   | is the `<` operator used?
-| `UsesMax`                        | is the `max`-like maximum value binary operator used?
-| `UsesMin`                        | is the `min`-like minimum value binary operator used?
-| `UsesMinus`                      | is the numeric `-` operator used?
-| `UsesModulo`                     | is the numeric `%-like` modulo operator used?
-| `UsesMultiply`                   | is the numeric `*` operator used?
-| `UsesNegation`                   | is the `!`-like not operator used?
-| `UsesNotEqual`                   | is the `!==`-like distinct operator used?
-| `UsesNotSame`                    | is the not reference-identical operator used?
-| `UsesNotSimilar`                 | is the not equal-ignoring-type operator used?
-| `UsesOr`                         | is the `||`-like or operator used?
-| `UsesOtherwise`                  | is the guard's otherwise operator used?
-| `UsesPlus`                       | is the numeric `+` operator used?
-| `UsesPush`                       | is the collection `insertAtEnd`-like operator used?
-| `UsesRound`                      | is the numeric `round`-like round operator used?
-| `UsesSame`                       | is the reference-identical operator used?
-| `UsesSelect`                     | is the collection `filter`-like operator used?
-| `UsesSetAt`                      | is the collection `[]=`-like operator used?
-| `UsesSimilar`                    | is the equal-ignoring-type operator used?
-| `UsesSize`                       | is the collection `length`-like size operator used?
+Primitive operators inspections are provided in two flavors:
 
+  * `Uses`: check whether the operator is referred
+  * `Calls`: check whether the operator is actually called within a function, procedure or method call. `Calls` inspections support matchers!
+
+| `Uses` Inspection                | `Calls` Inspection                | Meaning
+|----------------------------------|-----------------------------------|-----------------------
+| `UsesAbsolute`                   | `CallsAbsolute`                   | is the numeric `abs`-like absolute operator used/called?
+| `UsesAllSatisfy`                 | `CallsAllSatisfy`                 | is the collection `all`-like / `every`-like operator used/called?
+| `UsesAnd`                        | `CallsAnd`                        | is the `&&`-like and operator used/called?
+| `UsesAnySatisfy`                 | `CallsAnySatisfy`                 | is the collection `any`-like / `some`-like operator used/called?
+| `UsesBackwardComposition`        | `CallsBackwardComposition`        | is the `.`-like functional backward composition operator used/called?
+| `UsesBitwiseAnd`                 | `CallsBitwiseAnd`                 | is the bit-level `&`-like and operator used/called?
+| `UsesBitwiseLeftShift`           | `CallsBitwiseLeftShift`           | is the bit-level left `<<`-like shift operator used/called?
+| `UsesBitwiseOr`                  | `CallsBitwiseOr`                  | is the bit-level `|`-like or operator used/called?
+| `UsesBitwiseRightShift`          | `CallsBitwiseRightShift`          | is the bit-level right `>>`-like shift operator used/called?
+| `UsesBitwiseXor`                 | `CallsBitwiseXor`                 | is the bit-level `^`-like xor operator used/called?
+| `UsesCeil`                       | `CallsCeil`                       | is the numeric `ceil`-like ceiling operator used/called?
+| `UsesCollect`                    | `CallsCollect`                    | is the collection `map`-like operator used/called?
+| `UsesCount`                      | `CallsCount`                      | is the collection `count`-like operator used/called?
+| `UsesDetect`                     | `CallsDetect`                     | is the collection `find`-like search operator used/called?
+| `UsesDetectMax`                  | `CallsDetectMax`                  | is the collection `max`-like maximum operator used/called?
+| `UsesDetectMin`                  | `CallsDetectMin`                  | is the collection `min`-like minumum operator used/called?
+| `UsesDivide`                     | `CallsDivide`                     | is the numeric `/` operator used/called?
+| `UsesEqual`                      | `CallsEqual`                      | is the `===`-like equal operator used/called?
+| `UsesFlatten`                    | `CallsFlatten`                    | is the collection `flatten`-like operator used/called?
+| `UsesFloor`                      | `CallsFloor`                      | is the numeric `ceil`-like floor operator used/called?
+| `UsesForwardComposition`         | `CallsForwardComposition`         | is the `>>`-like functional forward composition operator used/called?
+| `UsesGather`                     | `CallsGather`                     | is the collection `flatmap`-like operator used/called?
+| `UsesGetAt`                      | `CallsGetAt`                      | is the collection `[]`-like operator used/called?
+| `UsesGreaterOrEqualThan`         | `CallsGreaterOrEqualThan`         | is the `>=` operator used/called?
+| `UsesGreaterThan`                | `CallsGreaterThan`                | is the `>` operator used/called?
+| `UsesHash`                       | `CallsHash`                       | is the `hashcode` operator used/called?
+| `UsesInject`                     | `CallsInject`                     | is the collection `reduce`-like / `fold`-like operator used/called?
+| `UsesLessOrEqualThan`            | `CallsLessOrEqualThan`            | is the `<=` operator used/called?
+| `UsesLessThan`                   | `CallsLessThan`                   | is the `<` operator used/called?
+| `UsesMax`                        | `CallsMax`                        | is the `max`-like maximum value binary operator used/called?
+| `UsesMin`                        | `CallsMin`                        | is the `min`-like minimum value binary operator used/called?
+| `UsesMinus`                      | `CallsMinus`                      | is the numeric `-` operator used/called?
+| `UsesModulo`                     | `CallsModulo`                     | is the numeric `%-like` modulo operator used/called?
+| `UsesMultiply`                   | `CallsMultiply`                   | is the numeric `*` operator used/called?
+| `UsesNegation`                   | `CallsNegation`                   | is the `!`-like not operator used/called?
+| `UsesNotEqual`                   | `CallsNotEqual`                   | is the `!==`-like distinct operator used/called?
+| `UsesNotSame`                    | `CallsNotSame`                    | is the not reference-identical operator used/called?
+| `UsesNotSimilar`                 | `CallsNotSimilar`                 | is the not equal-ignoring-type operator used/called?
+| `UsesOr`                         | `CallsOr`                         | is the `||`-like or operator used/called?
+| `UsesOtherwise`                  | `CallsOtherwise`                  | is the guard's otherwise operator used/called?
+| `UsesPlus`                       | `CallsPlus`                       | is the numeric `+` operator used/called?
+| `UsesPush`                       | `CallsPush`                       | is the collection `insertAtEnd`-like operator used/called?
+| `UsesRound`                      | `CallsRound`                      | is the numeric `round`-like round operator used/called?
+| `UsesSame`                       | `CallsSame`                       | is the reference-identical operator used/called?
+| `UsesSelect`                     | `CallsSelect`                     | is the collection `filter`-like operator used/called?
+| `UsesSetAt`                      | `CallsSetAt`                      | is the collection `[]=`-like operator used/called?
+| `UsesSimilar`                    | `CallsSimilar`                    | is the equal-ignoring-type operator used/called?
+| `UsesSize`                       | `CallsSize`                       | is the collection `length`-like size operator used/called?
+| `UsesSlice`                      | `CallsSlice`                      | is the slicing operator - like Ruby's `[..]` or Python's `[:]` - used/called?
 
 ## Imperative Inspections
 

--- a/gem/lib/locales/en.yml
+++ b/gem/lib/locales/en.yml
@@ -12,6 +12,7 @@ en:
       with_logic: ' with a boolean expression'
       with_math:  ' with a math expression'
       with_nil: ' with <code>%{keyword_Nil}</code>'
+      with_reference: ' with <code>%{value}</code>'
       with_nonliteral: ' with a non-literal expression'
       with_number: ' with number <code>%{value}</code>'
       with_string: ' with string <code>%{value}</code>'

--- a/gem/lib/locales/en.yml
+++ b/gem/lib/locales/en.yml
@@ -5,13 +5,14 @@ en:
       must_not: must not
       must: must
       solution: solution
+      with_anything: ' with some expression'
       with_char: ' with character <code>%{value}</code>'
       with_false: ' with value <code>%{keyword_False}</code>'
       with_literal: ' with a literal value'
       with_logic: ' with a boolean expression'
       with_math:  ' with a math expression'
       with_nil: ' with <code>%{keyword_Nil}</code>'
-      with_nonliteral: ' with a non-literal expresson'
+      with_nonliteral: ' with a non-literal expression'
       with_number: ' with number <code>%{value}</code>'
       with_string: ' with string <code>%{value}</code>'
       with_symbol: ' with symbol <code>%{value}</code>'

--- a/gem/lib/locales/es.yml
+++ b/gem/lib/locales/es.yml
@@ -5,6 +5,7 @@ es:
       must_not: no debe
       must: debe
       solution: la solución
+      with_anything: ' con alguna expresión'
       with_char: ' con el carácter <code>%{value}</code>'
       with_false: ' con el valor <code>%{keyword_False}</code>'
       with_literal: ' con un valor literal'

--- a/gem/lib/locales/es.yml
+++ b/gem/lib/locales/es.yml
@@ -12,6 +12,7 @@ es:
       with_logic: ' con una expresión booleana'
       with_math:  'con una expresión matemática'
       with_nil: ' con <code>%{keyword_Nil}</code>'
+      with_reference: ' con <code>%{value}</code>'
       with_nonliteral: ' con una expresión no literal'
       with_number: ' con el número <code>%{value}</code>'
       with_string: ' con la cadena <code>%{value}</code>'

--- a/gem/lib/locales/pt.yml
+++ b/gem/lib/locales/pt.yml
@@ -12,6 +12,7 @@ pt:
       with_logic: ' com uma expressão booleana'
       with_math: ' com uma expressão matemática'
       with_nil: ' com <code>%{keyword_Nil}</code>'
+      with_reference: ' com <code>%{value}</code>'
       with_nonliteral: ' com uma expressão não literal'
       with_number: ' com o número <code>%{value}</code>'
       with_string: ' com a string <code>%{value}</code>'

--- a/gem/lib/locales/pt.yml
+++ b/gem/lib/locales/pt.yml
@@ -5,6 +5,7 @@ pt:
       must_not: 'não deve'
       must: 'deve'
       solution: 'a solução'
+      with_anything: ' com alguma expressão'
       with_char: ' com o caractere <code>%{value}</code>'
       with_false: ' com o valor <code>%{keyword_False}</code>'
       with_literal: ' com um valor literal'

--- a/gem/lib/mulang/inspection.rb
+++ b/gem/lib/mulang/inspection.rb
@@ -13,7 +13,7 @@ module Mulang
       (?<type>[^:]+)
       (
         :(?<matcher>WithAnything|WithLiteral|WithNonliteral|WithLogic|WithMath|WithFalse|WithNil|WithTrue) |
-        :(?<matcher>WithChar|WithNumber|WithString|WithSymbol):(?<value>[^:]+) |
+        :(?<matcher>WithReference|WithChar|WithNumber|WithString|WithSymbol):(?<value>[^:]+) |
         :(?<target>[^:]+)(:(?<matcher>[^:]+)(:(?<value>[^:]+))?)?
       )?$}.gsub(/\s/, '')
 

--- a/gem/lib/mulang/inspection.rb
+++ b/gem/lib/mulang/inspection.rb
@@ -12,7 +12,7 @@ module Mulang
       ^(?<negation>Not:)?
       (?<type>[^:]+)
       (
-        :(?<matcher>WithLiteral|WithNonliteral|WithLogic|WithMath|WithFalse|WithNil|WithTrue) |
+        :(?<matcher>WithAnything|WithLiteral|WithNonliteral|WithLogic|WithMath|WithFalse|WithNil|WithTrue) |
         :(?<matcher>WithChar|WithNumber|WithString|WithSymbol):(?<value>[^:]+) |
         :(?<target>[^:]+)(:(?<matcher>[^:]+)(:(?<value>[^:]+))?)?
       )?$}.gsub(/\s/, '')

--- a/gem/lib/mulang/inspection/matcher.rb
+++ b/gem/lib/mulang/inspection/matcher.rb
@@ -2,8 +2,9 @@ class Mulang::Inspection::Matcher
   include Mulang::Inspection::Compacted
 
   TYPES = %w(
-    WithAnything WithChar WithFalse WithLiteral WithLogic
-    WithMath WithNil WithNonliteral WithNumber WithString
+    WithAnything WithChar WithFalse WithLiteral
+    WithLogic WithMath WithNil WithNonliteral
+    WithNumber WithReference WithString
     WithSymbol WithTrue)
 
   attr_accessor :type, :value

--- a/gem/lib/mulang/inspection/matcher.rb
+++ b/gem/lib/mulang/inspection/matcher.rb
@@ -1,7 +1,10 @@
 class Mulang::Inspection::Matcher
   include Mulang::Inspection::Compacted
 
-  TYPES = %w(WithChar WithFalse WithLiteral WithLogic WithMath WithNil WithNonliteral WithNumber WithString WithSymbol WithTrue)
+  TYPES = %w(
+    WithAnything WithChar WithFalse WithLiteral WithLogic
+    WithMath WithNil WithNonliteral WithNumber WithString
+    WithSymbol WithTrue)
 
   attr_accessor :type, :value
 

--- a/gem/spec/i18n_spec.rb
+++ b/gem/spec/i18n_spec.rb
@@ -72,6 +72,7 @@ describe Mulang::Expectation::I18n do
       it { expect(expectation('*', 'CallsSetAt').translate).to eq('solution must use <code>[]=</code>') }
       it { expect(expectation('*', 'CallsSetAt:WithAnything').translate).to eq('solution must use <code>[]=</code> with some expression') }
       it { expect(expectation('*', 'CallsSetAt:WithLiteral').translate).to eq('solution must use <code>[]=</code> with a literal value') }
+      it { expect(expectation('*', 'CallsSetAt:WithReference:x').translate).to eq('solution must use <code>[]=</code> with <code>x</code>') }
     end
   end
 
@@ -90,6 +91,8 @@ describe Mulang::Expectation::I18n do
     it { expect(expectation('foo', 'HasEmptyRepeat').translate).to eq('<code>foo</code> tem um <code>repeat</code> vazio') }
 
     it { expect(expectation('*', 'DeclaresComputationWithArity1:foo').translate).to eq('<code>foo</code> deve ter um parâmetro') }
+
+    it { expect(expectation('*', 'CallsSlice:WithReference:nomes').translate :Python).to eq('a solução deve utilizar <code>[:]</code> com <code>nomes</code>') }
 
   end
 
@@ -117,7 +120,7 @@ describe Mulang::Expectation::I18n do
       it { expect(expectation('foo', 'HasIf').translate(keyword_Repeat: 'repetir')).to eq('<code>foo</code> debe usar <code>if</code>') }
 
       it { expect(expectation('*', 'CallsSize:WithNonliteral').translate :Python).to eq('la solución debe usar <code>len</code> con una expresión no literal') }
-      it { expect(expectation('*', 'CallsSize:WithNonliteral').translate :JavaScript).to eq('la solución debe usar <code>length</code> con una expresión no literal') }
+      it { expect(expectation('*', 'CallsSize:WithReference:y').translate :JavaScript).to eq('la solución debe usar <code>length</code> con <code>y</code>') }
     end
 
     describe 'custom expectations' do

--- a/gem/spec/i18n_spec.rb
+++ b/gem/spec/i18n_spec.rb
@@ -23,7 +23,7 @@ describe Mulang::Expectation::I18n do
     it { expect(expectation('*', "Returns:WithFalse").translate).to eq('solution must return with value <code>false</code>') }
     it { expect(expectation('*', "UsesRepeat:WithMath").translate).to eq('solution must use <code>repeat</code> with a math expression') }
     it { expect(expectation('*', "Calls:g:WithLiteral").translate).to eq('solution must use <code>g</code> with a literal value') }
-    it { expect(expectation('*', "Calls:g:WithNonliteral").translate).to eq('solution must use <code>g</code> with a non-literal expresson') }
+    it { expect(expectation('*', "Calls:g:WithNonliteral").translate).to eq('solution must use <code>g</code> with a non-literal expression') }
     it { expect(expectation('*', "Calls:g:WithLogic").translate).to eq('solution must use <code>g</code> with a boolean expression') }
     it { expect(expectation('*', "DeclaresVariable:x:WithNumber:4").translate).to eq('solution must declare a variable <code>x</code> with number <code>4</code>') }
     it { expect(expectation('*', "Assigns:x:WithSymbol:bar").translate).to eq('solution must assign <code>x</code> with symbol <code>bar</code>') }
@@ -68,6 +68,10 @@ describe Mulang::Expectation::I18n do
       it { expect(expectation('*', 'UsesBitwiseXor').translate).to eq('solution must use <code>^</code>') }
       it { expect(expectation('*', 'UsesBitwiseLeftShift').translate).to eq('solution must use <code>&lt;&lt;</code>') }
       it { expect(expectation('*', 'UsesBitwiseRightShift').translate).to eq('solution must use <code>&gt;&gt;</code>') }
+
+      it { expect(expectation('*', 'CallsSetAt').translate).to eq('solution must use <code>[]=</code>') }
+      it { expect(expectation('*', 'CallsSetAt:WithAnything').translate).to eq('solution must use <code>[]=</code> with some expression') }
+      it { expect(expectation('*', 'CallsSetAt:WithLiteral').translate).to eq('solution must use <code>[]=</code> with a literal value') }
     end
   end
 
@@ -111,6 +115,9 @@ describe Mulang::Expectation::I18n do
 
       it { expect(expectation('foo', 'HasIf').translate(keyword_If: 'si')).to eq('<code>foo</code> debe usar <code>si</code>') }
       it { expect(expectation('foo', 'HasIf').translate(keyword_Repeat: 'repetir')).to eq('<code>foo</code> debe usar <code>if</code>') }
+
+      it { expect(expectation('*', 'CallsSize:WithNonliteral').translate :Python).to eq('la solución debe usar <code>len</code> con una expresión no literal') }
+      it { expect(expectation('*', 'CallsSize:WithNonliteral').translate :JavaScript).to eq('la solución debe usar <code>length</code> con una expresión no literal') }
     end
 
     describe 'custom expectations' do

--- a/gem/spec/inspection_spec.rb
+++ b/gem/spec/inspection_spec.rb
@@ -57,6 +57,7 @@ describe Mulang::Inspection do
   it { expect(Mulang::Inspection.parse("Returns:WithFalse")).to json_like(type: 'Returns', negated: false, matcher: {type: :with_false }) }
   it { expect(Mulang::Inspection.parse("Returns:WithNil")).to json_like(type: 'Returns', negated: false, matcher: {type: :with_nil }) }
   it { expect(Mulang::Inspection.parse("Returns:WithTrue")).to json_like(type: 'Returns', negated: false, matcher: {type: :with_true }) }
+  it { expect(Mulang::Inspection.parse("Returns:WithReference:c")).to json_like(type: 'Returns', negated: false, matcher: {type: :with_reference, value: "c" }) }
   it { expect(Mulang::Inspection.parse("Returns:WithChar:'c'")).to json_like(type: 'Returns', negated: false, matcher: {type: :with_char, value: "'c'" }) }
   it { expect(Mulang::Inspection.parse("Returns:WithNumber:2")).to json_like(type: 'Returns', negated: false, matcher: {type: :with_number, value: "2" }) }
   it { expect(Mulang::Inspection.parse("Returns:WithString:'hooper'")).to json_like(type: 'Returns', negated: false, matcher: {type: :with_string, value: "'hooper'" }) }

--- a/generators/tokens.rb
+++ b/generators/tokens.rb
@@ -78,8 +78,10 @@ def operators_translations_yml(operators, use)
 %Q{
   mulang:
     inspection:
-#{operators.map do |it|
-"      Uses#{it}: '%{binding} %{must} #{use} <code>%{operator_#{it}}</code>'"
+#{operators.flat_map do |it| [
+"      Uses#{it}: '%{binding} %{must} #{use} <code>%{operator_#{it}}</code>'",
+"      Calls#{it}: '%{binding} %{must} #{use} <code>%{operator_#{it}}</code>%{matching}'"
+]
 end.join("\n")}}
 end
 

--- a/spec/EdlSpec.hs
+++ b/spec/EdlSpec.hs
@@ -141,7 +141,7 @@ spec = do
     test "within `bar` calls `foo` with (0, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsNumber 0, IsSelf]))
     test "within `bar` calls `foo` with (\"hello\", self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsString "hello", IsSelf]))
     test "within `bar` calls `foo` with (`hello`, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsSymbol "hello", IsSelf]))
-    test "within `bar` calls `foo` with (&hello, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsReference "hello", IsSelf]))
+    test "within `bar` calls `foo` with (&`hello`, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsReference "hello", IsSelf]))
     test "within `bar` calls `foo` with ('a', self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsChar 'a', IsSelf]))
     test "within `bar` calls `foo` with (true, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsTrue, IsSelf]))
     test "within `bar` calls `foo` with (false, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsFalse, IsSelf]))
@@ -154,6 +154,10 @@ spec = do
     test "declares function like `total` that (uses not)" (simpleMatching "declares function" (Like "total") (Matching [That (simple "uses not" Any)]))
     test "declares function like `total` that (uses logic)" (simpleMatching "declares function" (Like "total") (Matching [That (simple "uses logic" Any)]))
     test "declares function like `total` that (uses math)" (simpleMatching "declares function" (Like "total") (Matching [That (simple "uses math" Any)]))
+
+    test "calls size with (&`items`)" (simpleMatching "calls size" Any (Matching [IsReference "items"]))
+    test "calls get at with (&`items`, 0)" (simpleMatching "calls get at" Any (Matching [IsReference "items", IsNumber 0.0]))
+    test "calls set at with (&`items`, 0, &`first_item`)" (simpleMatching "calls set at" Any (Matching [IsReference "items", IsNumber 0.0, IsReference "first_item"]))
 
     test "declares function like `total` that (returns that (uses math))" (
       simpleMatching "declares function" (Like "total") (Matching [That (

--- a/spec/EdlSpec.hs
+++ b/spec/EdlSpec.hs
@@ -141,6 +141,7 @@ spec = do
     test "within `bar` calls `foo` with (0, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsNumber 0, IsSelf]))
     test "within `bar` calls `foo` with (\"hello\", self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsString "hello", IsSelf]))
     test "within `bar` calls `foo` with (`hello`, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsSymbol "hello", IsSelf]))
+    test "within `bar` calls `foo` with (&hello, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsReference "hello", IsSelf]))
     test "within `bar` calls `foo` with ('a', self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsChar 'a', IsSelf]))
     test "within `bar` calls `foo` with (true, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsTrue, IsSelf]))
     test "within `bar` calls `foo` with (false, self)" (simpleMatchingWithin "bar" "calls" (Named "foo") (Matching [IsFalse, IsSelf]))

--- a/spec/ExpectationsCompilerSpec.hs
+++ b/spec/ExpectationsCompilerSpec.hs
@@ -193,6 +193,10 @@ spec = do
     run (Assignment "x" (MuSymbol "foo")) "*" "Assigns:x:WithSymbol:foo" `shouldBe` True
     run (Assignment "x" (MuSymbol "foo")) "*" "Assigns:x:WithSymbol:bar" `shouldBe` False
 
+  it "works with Assigns WithReference" $ do
+    run (Assignment "x" (Reference "foo")) "*" "Assigns:x:WithReference:foo" `shouldBe` True
+    run (Assignment "x" (Reference "foo")) "*" "Assigns:x:WithReference:bar" `shouldBe` False
+
   it "works with Assigns WithChar" $ do
     run (java "class Foo { char x = 'a'; }") "Foo" "Assigns:x:WithChar:'a'" `shouldBe` True
     run (java "class Foo { char x = 'b'; }") "Foo" "Assigns:x:WithChar:'a'" `shouldBe` False

--- a/spec/ExpectationsCompilerSpec.hs
+++ b/spec/ExpectationsCompilerSpec.hs
@@ -300,6 +300,41 @@ spec = do
     run (py "x['y'] = 10") "*" "UsesGetAt" `shouldBe` False
     run (py "x['y'] = 10") "*" "UsesSetAt" `shouldBe` True
 
+  it "works with primitive operators call in py - single matcher" $ do
+    run (py "len('hello')") "*" "CallsSize" `shouldBe` True
+    run (py "len('hello')") "*" "CallsSize:WithLiteral" `shouldBe` True
+    run (py "len('hello')") "*" "CallsSize:WithString:\"hello\"" `shouldBe` True
+    run (py "len('hello')") "*" "CallsSize:WithString:\"baz\"" `shouldBe` False
+
+  it "works with primitive operators call in py - two basic matchers" $ do
+    run (py "x[0]") "*" "CallsGetAt" `shouldBe` True
+
+    run (py "x[0]") "*" "CallsGetAt:WithAnything" `shouldBe` True
+    run (py "x[0]") "*" "CallsGetAt:WithLiteral" `shouldBe` False
+
+    run (py "x[0]") "*" "CallsGetAt:WithAnything:WithAnything" `shouldBe` True
+    run (py "x[0]") "*" "CallsGetAt:WithNonliteral:WithAnything" `shouldBe` True
+    run (py "x[0]") "*" "CallsGetAt:WithNonliteral:WithLiteral" `shouldBe` True
+
+  it "works with primitive operators call in py - two matchers with args" $ do
+    run (py "x[0]") "*" "CallsGetAt:WithAnything:WithLiteral" `shouldBe` True
+    run (py "x[0]") "*" "CallsGetAt:WithAnything:WithNumber:0" `shouldBe` True
+    run (py "x[0]") "*" "CallsGetAt:WithAnything:WithNumber:2" `shouldBe` False
+    run (py "x[0]") "*" "CallsSetAt:WithAnything:WithNumber:0" `shouldBe` False
+
+  it "works with primitive operators call in py - three matchers" $ do
+    run (py "x[0] = 9") "*" "CallsGetAt:WithAnything:WithNumber:0" `shouldBe` False
+    run (py "x[0] = 9") "*" "CallsSetAt:WithAnything:WithNumber:5" `shouldBe` False
+    run (py "x[0] = 9") "*" "CallsSetAt:WithAnything:WithNumber:0" `shouldBe` True
+
+    run (py "x[0] = 9") "*" "CallsSetAt:WithAnything:WithNumber:0:WithNumber:9" `shouldBe` True
+    run (py "x[0] = 9") "*" "CallsSetAt:WithAnything:WithNumber:0:WithNumber:0" `shouldBe` False
+
+    run (py "x['y'] = 10") "*" "CallsGetAt:WithAnything:WithString:\"y\"" `shouldBe` False
+    run (py "x['y'] = 10") "*" "CallsSetAt:WithAnything:WithString:\"j\"" `shouldBe` False
+    run (py "x['y'] = 10") "*" "CallsSetAt:WithAnything:WithString:\"y\"" `shouldBe` True
+    run (py "x['y'] = 10") "*" "CallsSetAt:WithAnything:WithString:\"y\":WithNumber:10" `shouldBe` True
+
   it "works with primitive operators essence with ast" $ do
     run (Primitive Equal)    "*" "IsEqual" `shouldBe` True
     run (Primitive NotEqual) "*" "IsEqual" `shouldBe` False

--- a/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
+++ b/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
@@ -223,6 +223,7 @@ compileClauses = withEvery . f
     f :: [E.Clause] -> [Inspection]
     f (E.IsAnything:args)       = isAnything : (f args)
     f (E.IsChar value:args)     = isChar value : (f args)
+    f (E.IsReference value:args)= isReference value : (f args)
     f (E.IsFalse:args)          = isBool False : (f args)
     f (E.IsLiteral:args)        = isLiteral : (f args)
     f (E.IsLogic:args)          = usesLogic : (f args)

--- a/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
+++ b/src/Language/Mulang/Analyzer/EdlQueryCompiler.hs
@@ -12,7 +12,7 @@ import Language.Mulang.Consult (Consult)
 import Language.Mulang.Counter (plus)
 import Language.Mulang.Inspector.Primitive (atLeast, atMost, exactly)
 import Language.Mulang.Inspector.Literal (isNil, isNumber, isBool, isChar, isString, isSymbol, isSelf, isLiteral)
-import Language.Mulang.Analyzer.Synthesizer (decodeIsInspection, decodeUsageInspection, decodeDeclarationInspection)
+import Language.Mulang.Analyzer.Synthesizer (decodeIsInspection, decodeCallsInspection, decodeUsageInspection, decodeDeclarationInspection)
 
 import qualified Language.Mulang.Edl.Expectation as E
 
@@ -93,6 +93,7 @@ compileCounter = f
   f "UsesSwitch"                 m            = plainMatching countSwitches m
   f "UsesWhile"                  m            = plainMatching countWhiles m
   f "UsesYield"                  m            = plainMatching countYiels m
+  f (primitiveCalls -> Just p)   m            = plainMatching (\m -> countPrimitiveCalls m p) m
   f (primitiveUsage -> Just p)   E.Unmatching = plain (countUsesPrimitive p)
   f _                            _            = Nothing
 
@@ -183,6 +184,7 @@ compileInspection = f
   f "UsesType"                         E.Unmatching   = bound usesType
   f "UsesWhile"                        m              = plainMatching usesWhileMatching m
   f "UsesYield"                        m              = plainMatching usesYieldMatching m
+  f (primitiveCalls -> Just p)         m              = plainMatching (\m -> callsPrimitiveMatching m p) m
   f (primitiveDeclaration -> Just p)   E.Unmatching   = plain (declaresPrimitive p)
   f (primitiveUsage -> Just p)         E.Unmatching   = plain (usesPrimitive p)
   f (primitiveEssence -> Just p)       E.Unmatching   = plain (isPrimitive p)
@@ -191,6 +193,7 @@ compileInspection = f
 primitiveEssence = decodeIsInspection
 primitiveUsage = decodeUsageInspection
 primitiveDeclaration = decodeDeclarationInspection
+primitiveCalls = decodeCallsInspection
 
 contextual :: ContextualizedConsult a -> Maybe (ContextualizedBoundConsult a)
 contextual = Just . contextualizedBind

--- a/src/Language/Mulang/Analyzer/ExpectationsCompiler.hs
+++ b/src/Language/Mulang/Analyzer/ExpectationsCompiler.hs
@@ -33,7 +33,7 @@ compileScope _                     q = Decontextualize q
 compileCQuery :: [String] -> CQuery
 compileCQuery []                            = compileCQuery ["Parses","*"]
 compileCQuery [verb]                        = compileCQuery [verb,"*"]
-compileCQuery [verb,name]                   | Map.member name nullaryMatchers = compileCQuery [verb,"*",name]
+compileCQuery (verb:name:args)              | Map.member name nullaryMatchers = compileCQuery (verb:"*":name:args)
 compileCQuery (verb:"WithChar":args)        = compileCQuery (verb:"*":"WithChar":args)
 compileCQuery (verb:"WithNumber":args)      = compileCQuery (verb:"*":"WithNumber":args)
 compileCQuery (verb:"WithString":args)      = compileCQuery (verb:"*":"WithString":args)
@@ -63,6 +63,7 @@ compileMatcher = matching . f
 
 nullaryMatchers =
   Map.fromList [
+    ("WithAnything", IsAnything),
     ("WithFalse", IsFalse),
     ("WithLiteral", IsLiteral),
     ("WithLogic", IsLogic),

--- a/src/Language/Mulang/Analyzer/Synthesizer.hs
+++ b/src/Language/Mulang/Analyzer/Synthesizer.hs
@@ -4,6 +4,7 @@ module Language.Mulang.Analyzer.Synthesizer (
   encodeUsageInspection,
   encodeDeclarationInspection,
   decodeIsInspection,
+  decodeCallsInspection,
   decodeUsageInspection,
   decodeDeclarationInspection,
   generateInspectionEncodingRules,
@@ -39,6 +40,9 @@ encodeInspection prefix = (prefix ++) . show
 
 decodeIsInspection :: Decoder Operator
 decodeIsInspection = decodeInspection "Is"
+
+decodeCallsInspection :: Decoder Operator
+decodeCallsInspection = decodeInspection "Calls"
 
 decodeUsageInspection :: Decoder Operator
 decodeUsageInspection = decodeInspection "Uses"

--- a/src/Language/Mulang/Edl/Expectation.hs
+++ b/src/Language/Mulang/Edl/Expectation.hs
@@ -70,6 +70,7 @@ data Clause
   | IsNil
   | IsNonliteral
   | IsNumber Double
+  | IsReference String
   | IsSelf
   | IsString String
   | IsSymbol String

--- a/src/Language/Mulang/Edl/Lexer.x
+++ b/src/Language/Mulang/Edl/Lexer.x
@@ -58,7 +58,7 @@ tokens :-
   ' @char '     { mkChar }
   \" @string \" { mkString TString }
   ` @symbol `   { mkString TSymbol }
-  & @identifier { mkReference }
+  &` @symbol `  { mkReference }
   ("+" | "-")? @float_number { token TNumber readFloat }
   ("+" | "-")? $digit+ { token TNumber (fromIntegral.readInt) }
 
@@ -215,11 +215,13 @@ mkChar :: Action
 mkChar = token TChar (head.tail)
 
 mkString :: (String -> Token) -> Action
-mkString kind = token kind (\str -> drop 1 . take (length str - 1) $ str)
+mkString kind = token kind (stripString 1)
 
 mkIdentifier :: Action
 mkIdentifier = token TIdentifier id
 
 mkReference :: Action
-mkReference = token TReference (drop 1)
+mkReference = token TReference (stripString 2)
+
+stripString n str = drop n . take (length str - 1) $ str
 }

--- a/src/Language/Mulang/Edl/Lexer.x
+++ b/src/Language/Mulang/Edl/Lexer.x
@@ -55,9 +55,10 @@ tokens :-
 
   "%%" ($not_eol_char)* ;  -- skip comments
 
-  ' @char '    { mkChar }
-  \" @string \"     { mkString TString }
+  ' @char '     { mkChar }
+  \" @string \" { mkString TString }
   ` @symbol `   { mkString TSymbol }
+  & @identifier { mkReference }
   ("+" | "-")? @float_number { token TNumber readFloat }
   ("+" | "-")? $digit+ { token TNumber (fromIntegral.readInt) }
 
@@ -134,6 +135,7 @@ data Token
   | TOpenParen
   | TOr
   | TPlus
+  | TReference { referenceValue :: String }
   | TSelf
   | TSemi
   | TSomething
@@ -217,4 +219,7 @@ mkString kind = token kind (\str -> drop 1 . take (length str - 1) $ str)
 
 mkIdentifier :: Action
 mkIdentifier = token TIdentifier id
+
+mkReference :: Action
+mkReference = token TReference (drop 1)
 }

--- a/src/Language/Mulang/Edl/Parser.y
+++ b/src/Language/Mulang/Edl/Parser.y
@@ -20,6 +20,7 @@ import           Control.Monad.Error
 
   and { TAnd {} }
   anything { TAnything {} }
+  reference { TReference {} }
   atLeast { TAtLeast {} }
   atMost { TAtMost {} }
   cand { TCAnd {} }
@@ -161,6 +162,7 @@ Clauses : Clause { [$1] }
 Clause :: { Clause }
 Clause : number { IsNumber . numberValue $ $1 }
   | string { IsString . stringValue $ $1 }
+  | reference { IsReference . referenceValue $ $1 }
   | char { IsChar . charValue $ $1 }
   | symbol { IsSymbol . symbolValue $ $1 }
   | anything { IsAnything }
@@ -194,6 +196,7 @@ scopeOperatorError operator = unlines [
 m (TChar v) = "char " ++ show v ++ " is not expected here"
 m (TIdentifier id) = "Unexpected keyword " ++ id
 m (TNumber v) = "number " ++ show v ++ " is not expected here"
+m (TReference v) = "reference " ++ show v ++ " is not expected here"
 m (TString v) = "string " ++ show v ++ " is not expected here"
 m (TSymbol v) = "symbol " ++ v ++ " is not expected here"
 m TAnd = "and is not expected here"

--- a/src/Language/Mulang/Inspector/Generic.hs
+++ b/src/Language/Mulang/Inspector/Generic.hs
@@ -3,7 +3,10 @@ module Language.Mulang.Inspector.Generic (
   assignsMatching,
   calls,
   callsMatching,
+  callsPrimitive,
+  callsPrimitiveMatching,
   countCalls,
+  countPrimitiveCalls,
   countFors,
   countFunctions,
   countIfs,
@@ -99,6 +102,17 @@ countCalls :: Matcher -> BoundCounter
 countCalls matcher p = countExpressions f
   where f (Call (Reference id) arguments) = p id && matcher arguments
         f _                               = False
+
+callsPrimitive :: Operator -> Inspection
+callsPrimitive = unmatching callsPrimitiveMatching
+
+callsPrimitiveMatching :: Matcher -> Operator -> Inspection
+callsPrimitiveMatching matcher = positive . (countPrimitiveCalls matcher)
+
+countPrimitiveCalls :: Matcher -> Operator -> Counter
+countPrimitiveCalls matcher o = countExpressions f
+  where f (Call callee arguments) = isPrimitive o callee && matcher arguments
+        f _                       = False
 
 delegates :: BoundInspection
 delegates = decontextualize . delegates'

--- a/src/Language/Mulang/Inspector/Literal.hs
+++ b/src/Language/Mulang/Inspector/Literal.hs
@@ -1,6 +1,7 @@
 module Language.Mulang.Inspector.Literal (
   isAnything,
   isBool,
+  isReference,
   isChar,
   isNil,
   isNumber,
@@ -32,6 +33,10 @@ isNumber = (==) . MuNumber
 
 isBool :: Bool -> Inspection
 isBool = (==) . MuBool
+
+isReference :: String -> Inspection
+isReference = (==) . Reference
+
 
 isString :: String -> Inspection
 isString = (==) . MuString

--- a/src/Language/Mulang/Inspector/Matcher.hs
+++ b/src/Language/Mulang/Inspector/Matcher.hs
@@ -10,7 +10,7 @@ import           Language.Mulang.Inspector.Primitive (Inspection)
 
 type Matcher = [Expression] -> Bool
 
--- | Creates a simple matcher that evaluates the given inspection only againts the first of its arguments
+-- | Creates a simple matcher that evaluates the given inspection only against the first of its arguments
 with :: Inspection -> Matcher
 with inspection = inspection . head
 


### PR DESCRIPTION
# :dart: Goal

To allow primitive calls to be checked using matchers

# :memo: Details

* Documentation updated
* A `WithReference` matcher was added 
* `WithAnything` matchers was supported as part of the plain inspections - although it will not be very useful yet. 
* Some typos were fixed. 

