### PR TITLE
Feature normalize functions by parts

### DIFF
--- a/spec/GenericSpec.hs
+++ b/spec/GenericSpec.hs
@@ -86,6 +86,15 @@ spec = do
       it "is True when functions is declared" $ do
         declaresFunction (named "f") (js "function f(x) {return 1}") `shouldBe` True
 
+      it "is True when a function by parts is declared" $ do
+        declaresFunction (named "f") (js "function f(x) { if (x > 4) { return 1 } else { return 5 } }") `shouldBe` True
+
+      it "is True when a function by parts is declared using an imperative style" $ do
+        declaresFunction (named "f") (js "function f(x) { if (x > 4) { return 1 } return 5 }") `shouldBe` True
+
+      it "is False when a partial function is declared" $ do
+        declaresFunction (named "f") (js "function f(x) { if (x > 4) { return 1 } }") `shouldBe` False
+
       it "is True when functions is declared" $ do
         declaresFunction (named "f") (js "function f(x) {return 1}") `shouldBe` True
 

--- a/spec/GenericSpec.hs
+++ b/spec/GenericSpec.hs
@@ -16,7 +16,7 @@ import           Language.Mulang.Normalizers.Haskell (haskellNormalizationOption
 import           Language.Mulang.Parsers.Haskell
 import           Language.Mulang.Parsers.Java (java)
 import           Language.Mulang.Parsers.JavaScript
-import           Language.Mulang.Parsers.Python (py2, py3)
+import           Language.Mulang.Parsers.Python (npy, py2, py3)
 import           Language.Mulang.Transform.Normalizer
 
 nhs = normalize haskellNormalizationOptions . hs
@@ -81,6 +81,16 @@ spec = do
 
       it "is False when constant is declared with a variable literal" $ do
         declaresFunction (named "f") (hs "f = snd") `shouldBe` False
+
+    describe "with function declarations, npy" $ do
+      it "is True when a function by parts is declared" $ do
+        declaresFunction (named "f") (npy "def f(x):\n\tif x > 4:\n\t\treturn 1\n\telse:\n\t\treturn 5") `shouldBe` True
+
+      it "is True when a function by parts is declared using an imperative style" $ do
+        declaresFunction (named "f") (npy "def f(x):\n\tif x > 4:\n\t\treturn 1\n\treturn 5") `shouldBe` True
+
+      it "is False when a partial function is declared" $ do
+        declaresFunction (named "f") (npy "def f(x):\n\tif x > 4:\n\t\treturn 1\n") `shouldBe` False
 
     describe "with function declarations, js" $ do
       it "is True when functions is declared" $ do

--- a/spec/NormalizerSpec.hs
+++ b/spec/NormalizerSpec.hs
@@ -6,14 +6,12 @@ module NormalizerSpec (spec) where
   import           Language.Mulang.Parsers.Haskell (hs)
   import           Language.Mulang.Parsers.Java (java)
   import           Language.Mulang.Parsers.JavaScript (js)
-  import           Language.Mulang.Parsers.Python (py)
+  import           Language.Mulang.Parsers.Python (npy, py)
   import           Language.Mulang.Normalizers.Java (javaNormalizationOptions)
-  import           Language.Mulang.Normalizers.Python (pythonNormalizationOptions)
   import           Language.Mulang.Normalizers.Haskell (haskellNormalizationOptions)
   import           Language.Mulang.Transform.Normalizer
 
   njava = normalize javaNormalizationOptions . java
-  npy = normalize pythonNormalizationOptions . py
   nhs = normalize haskellNormalizationOptions . hs
 
   spec :: Spec
@@ -79,10 +77,10 @@ module NormalizerSpec (spec) where
       let n = normalize options
 
       it "does not insert return in single literal statement" $ do
-        n (py "def x(): x = 1") `shouldBe`  SimpleProcedure "x" [] (Assignment "x" (MuNumber 1.0))
+        n (npy "def x(): x = 1") `shouldBe`  SimpleProcedure "x" [] (Assignment "x" (MuNumber 1.0))
 
       it "inserts return in single literal expression" $ do
-        n (py "def x(): 3") `shouldBe`  SimpleProcedure "x" [] (Return (MuNumber 3.0))
+        n (npy "def x(): 3") `shouldBe`  SimpleProcedure "x" [] (Return (MuNumber 3.0))
 
       it "does not insert return in empty block" $ do
         n (SimpleFunction "x" [] None) `shouldBe`  (SimpleFunction "x" [] None)

--- a/src/Language/Mulang/Analyzer/Analysis/Json.hs
+++ b/src/Language/Mulang/Analyzer/Analysis/Json.hs
@@ -28,6 +28,7 @@ instance FromJSON NormalizationOptions where
         <*> v .:? "convertObjectLevelLambdaVariableIntoMethod"    .!= convertObjectLevelLambdaVariableIntoMethod d
         <*> v .:? "convertObjectLevelVariableIntoAttribute"       .!= convertObjectLevelVariableIntoAttribute d
         <*> v .:? "convertObjectIntoDict"                         .!= convertObjectIntoDict d
+        <*> v .:? "convertPartialProcedureIntoFunction"           .!= convertPartialProcedureIntoFunction d
         <*> v .:? "sortSequenceDeclarations"                      .!= sortSequenceDeclarations d
         <*> v .:? "insertImplicitReturn"                          .!= insertImplicitReturn d
         <*> v .:? "compactSequences"                              .!= compactSequences d

--- a/src/Language/Mulang/Analyzer/Analysis/Json.hs
+++ b/src/Language/Mulang/Analyzer/Analysis/Json.hs
@@ -28,7 +28,7 @@ instance FromJSON NormalizationOptions where
         <*> v .:? "convertObjectLevelLambdaVariableIntoMethod"    .!= convertObjectLevelLambdaVariableIntoMethod d
         <*> v .:? "convertObjectLevelVariableIntoAttribute"       .!= convertObjectLevelVariableIntoAttribute d
         <*> v .:? "convertObjectIntoDict"                         .!= convertObjectIntoDict d
-        <*> v .:? "convertPartialProcedureIntoFunction"           .!= convertPartialProcedureIntoFunction d
+        <*> v .:? "convertProcedureByPartsIntoFunction"           .!= convertProcedureByPartsIntoFunction d
         <*> v .:? "sortSequenceDeclarations"                      .!= sortSequenceDeclarations d
         <*> v .:? "insertImplicitReturn"                          .!= insertImplicitReturn d
         <*> v .:? "compactSequences"                              .!= compactSequences d

--- a/src/Language/Mulang/Normalizers/JavaScript.hs
+++ b/src/Language/Mulang/Normalizers/JavaScript.hs
@@ -9,5 +9,6 @@ javaScriptNormalizationOptions = unnormalized {
   convertObjectLevelFunctionIntoMethod = True,
   convertObjectLevelLambdaVariableIntoMethod = True,
   convertObjectLevelVariableIntoAttribute = True,
-  sortSequenceDeclarations = SortUniqueNonVariables
+  sortSequenceDeclarations = SortUniqueNonVariables,
+  convertPartialProcedureIntoFunction = True
 }

--- a/src/Language/Mulang/Normalizers/JavaScript.hs
+++ b/src/Language/Mulang/Normalizers/JavaScript.hs
@@ -10,5 +10,5 @@ javaScriptNormalizationOptions = unnormalized {
   convertObjectLevelLambdaVariableIntoMethod = True,
   convertObjectLevelVariableIntoAttribute = True,
   sortSequenceDeclarations = SortUniqueNonVariables,
-  convertPartialProcedureIntoFunction = True
+  convertProcedureByPartsIntoFunction = True
 }

--- a/src/Language/Mulang/Normalizers/Python.hs
+++ b/src/Language/Mulang/Normalizers/Python.hs
@@ -4,6 +4,6 @@ import Language.Mulang.Transform.Normalizer (unnormalized, NormalizationOptions(
 
 pythonNormalizationOptions :: NormalizationOptions
 pythonNormalizationOptions = unnormalized {
-  sortSequenceDeclarations = SortAllNonVariables,
+  sortSequenceDeclarations = SortUniqueNonVariables,
   convertProcedureByPartsIntoFunction = True
 }

--- a/src/Language/Mulang/Normalizers/Python.hs
+++ b/src/Language/Mulang/Normalizers/Python.hs
@@ -5,5 +5,5 @@ import Language.Mulang.Transform.Normalizer (unnormalized, NormalizationOptions(
 pythonNormalizationOptions :: NormalizationOptions
 pythonNormalizationOptions = unnormalized {
   sortSequenceDeclarations = SortAllNonVariables,
-  convertPartialProcedureIntoFunction = True
+  convertProcedureByPartsIntoFunction = True
 }

--- a/src/Language/Mulang/Normalizers/Python.hs
+++ b/src/Language/Mulang/Normalizers/Python.hs
@@ -4,5 +4,6 @@ import Language.Mulang.Transform.Normalizer (unnormalized, NormalizationOptions(
 
 pythonNormalizationOptions :: NormalizationOptions
 pythonNormalizationOptions = unnormalized {
-  sortSequenceDeclarations = SortAllNonVariables
+  sortSequenceDeclarations = SortAllNonVariables,
+  convertPartialProcedureIntoFunction = True
 }

--- a/src/Language/Mulang/Parsers/Python.hs
+++ b/src/Language/Mulang/Parsers/Python.hs
@@ -1,4 +1,5 @@
 module Language.Mulang.Parsers.Python (
+  npy,
   py,
   py2,
   py3,
@@ -10,9 +11,11 @@ import qualified Language.Mulang.Ast as M
 import qualified Language.Mulang.Ast.Operator as O
 import           Language.Mulang.Builder (compactMap, compactTuple)
 import           Language.Mulang.Parsers
+import           Language.Mulang.Transform.Normalizer (normalize)
 
 import qualified Language.Python.Version3.Parser as Python3
 import qualified Language.Python.Version2.Parser as Python2
+import           Language.Mulang.Normalizers.Python (pythonNormalizationOptions)
 import           Language.Python.Common.Token (Token)
 import           Language.Python.Common.AST
 
@@ -23,7 +26,8 @@ import           Data.Maybe (fromMaybe, listToMaybe)
 import           Control.Fallible
 import           Control.Monad (msum)
 
-py, py2, py3 :: Parser
+npy, py, py2, py3 :: Parser
+npy = normalize pythonNormalizationOptions . py
 py = py3
 py2 = parsePythonOrFail Python2.parseModule
 py3 = parsePythonOrFail Python3.parseModule


### PR DESCRIPTION
# :dart: Goal

To allow functions defined by parts to also be considered functions

# :memo: Details

A new normalization mode was introduced, and enabled by default in Python and JavaScript. Also, sorting of python expressions is more conservative now. 


